### PR TITLE
Build nginx container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,8 @@ jobs:
           echo "export BRANCH_SLUG=$BRANCH_SLUG" >> $BASH_ENV
           echo "export STACK_NAME=$STACK_NAME" >> $BASH_ENV
           echo "export VIRTUALHOST=${BRANCH_SLUG}.${CIRCLE_PROJECT_REPONAME}.dev.wdr.io" >> $BASH_ENV
-          echo "export DRUPALDOCKERIMAGE=wunder/${CIRCLE_PROJECT_REPONAME}:${CIRCLE_SHA1}" >> $BASH_ENV
+          echo "export DOCKER_IMAGE_PREFIX=$CIRCLE_PROJECT_REPONAME" >> $BASH_ENV
+          echo "export DOCKER_IMAGE_VERSION=$CIRCLE_SHA1" >> $BASH_ENV
           echo "export LOADBALANCER=loadbalancer/dev_lb" >> $BASH_ENV
           echo "export BASICAUTH=wunder:wunder" >> $BASH_ENV
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
+# Ignore file for the Drupal container.
 **/*.md
 **/CHANGELOG*
 **/README*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+# Dockerfile for the Drupal container.
 FROM wodby/drupal-php:7.1-3.3.1
 
 COPY --chown=www-data:www-data . /var/www/html

--- a/kontena.yml
+++ b/kontena.yml
@@ -72,6 +72,8 @@ services:
       KONTENA_LB_VIRTUAL_HOSTS: "{{ virtualhost }}"
     links:
       - {{ loadbalancer }}
+    volumes:
+      - drupal_files:/var/www/html/web/sites/default/files
   drupal:
     image: images.kontena.io/wunder/{{ docker-image-prefix }}-drupal:{{ docker-image-version }}
     build:
@@ -96,7 +98,6 @@ services:
         # {% endif %}
     volumes:
       - drupal_files:/var/www/html/web/sites/default/files
-      - /var/www/html/web
   db:
     image: mariadb:10.2
     stateful: true

--- a/kontena.yml
+++ b/kontena.yml
@@ -43,14 +43,21 @@ variables:
       service_link:
         prompt: Choose a loadbalancer
         image: kontena/lb
-  drupal_docker_image:
+  docker-image-prefix:
     type: string
     from:
-      env: DRUPALDOCKERIMAGE
-      prompt: Drupal Docker image (wunder/projectname:version)
+      env: DOCKER_IMAGE_PREFIX
+      prompt: Docker image prefix
+  docker-image-version:
+    type: string
+    from:
+      env: DOCKER_IMAGE_VERSION
+      prompt: Docker image version
 services:
   nginx:
-    image: wodby/drupal-nginx:8-1.13-3.0.2
+    image: images.kontena.io/wunder/{{ docker-image-prefix }}-nginx:{{ docker-image-version }}
+    build:
+      context: web
     instances: 1
     depends_on:
       - drupal
@@ -65,13 +72,10 @@ services:
       KONTENA_LB_VIRTUAL_HOSTS: "{{ virtualhost }}"
     links:
       - {{ loadbalancer }}
-    volumes_from:
-      - drupal-%s
   drupal:
-    image: images.kontena.io/${drupal_docker_image}
+    image: images.kontena.io/wunder/{{ docker-image-prefix }}-drupal:{{ docker-image-version }}
     build:
       context: .
-      dockerfile: Dockerfile
     instances: 1
     environment:
       PHP_FPM_CLEAR_ENV: "no"

--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,0 +1,18 @@
+# Ignore file for the nginx container.
+**/*.md
+**/CHANGELOG*
+**/README*
+**/LICENSE*
+kontena.yml
+.circleci/*
+phpcs.xml
+**/*.sql
+**/*.gz
+**/*.zip
+node_modules
+**/*.php
+**/*.module
+**/*.install
+**/*.yml
+core/**/tests
+modules/contrib/**/tests

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,7 @@
+# Dockerfile for building nginx.
+FROM wodby/drupal-nginx:8-1.13-3.0.2
+
+COPY --chown=www-data:www-data . /var/www/html/web
+
+USER www-data
+


### PR DESCRIPTION
In order to avoid needing to share files from the codebase between Drupal and nginx as a volume, we can copy all the relevant files (css, js, images, fonts, etc) into a dedicated folder at build time, and build our nginx container based on that.

Resulting site here: http://feature-nginx-container-build.drupal-project.dev.wdr.io/