### PR TITLE
Use major tags of wodby images.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for the Drupal container.
-FROM wodby/drupal-php:7.1-3.3.1
+FROM wodby/drupal-php:7.1
 
 COPY --chown=www-data:www-data . /var/www/html
 USER www-data

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for building nginx.
-FROM wodby/drupal-nginx:8-1.13-3.0.2
+FROM wodby/drupal-nginx:8-1.13
 
 COPY --chown=www-data:www-data . /var/www/html/web
 


### PR DESCRIPTION
We should use major tags instead of specific fixed releases of the images.