### PR TITLE
Fix broken docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for the Drupal container.
-FROM wodby/drupal-php:7.1
+FROM wodby/drupal-php:7.1-3.4.0
 
 COPY --chown=www-data:www-data . /var/www/html
 USER www-data

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for building nginx.
-FROM wodby/drupal-nginx:8-1.13
+FROM wodby/drupal-nginx:8-1.13-3.0.4
 
 COPY --chown=www-data:www-data . /var/www/html/web
 


### PR DESCRIPTION
Wodby doesn't tag major versions, so pin the latest working version for now.