### PR TITLE
Skip file system permissions hardening when using lando.

### DIFF
--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -16,6 +16,9 @@ if (getenv('LANDO_INFO')) {
 
   // Use the hash_salt setting from Lando.
   $settings['hash_salt'] = getenv('HASH_SALT');
+
+  //Skip file system permissions hardening when using local development with Lando.
+  $settings['skip_permissions_hardening'] = TRUE;
 }
 
 // Location of the site configuration files.


### PR DESCRIPTION
This avoids issues with settings.php being set to read only, which can be an issue in local environments.