### PR TITLE
Use SemVer for silta/silta orb reference.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  silta: silta/silta@0.1
+  silta: silta/silta@0.1.0
 
 workflows:
   version: 2


### PR DESCRIPTION
As per https://circleci.com/docs/2.0/using-orbs/#design-methodology and https://circleci.com/docs/2.0/orb-intro/#importing-partner-orbs.