### PR TITLE
Feature/slt 108 skip unnecessary builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  silta: silta/silta@dev:feature/slt-108-skip-unnecessary-builds
+  silta: silta/silta@0.1
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,28 +12,22 @@ workflows:
           post-validation:
             - run: echo "You can add additional validation here!"
 
-      - silta/drupal-build:
-          name: build
-          context: global_nonprod
+      - silta/drupal-build-deploy: &build-deploy
+          name: build-deploy
           codebase-build:
             - silta/drupal-composer-install
             - silta/yarn-install
-
-      - silta/drupal-deploy:
-          name: deploy
           context: global_nonprod
-          requires:
-            - build
           filters:
             branches:
               ignore: production
 
-      - silta/drupal-deploy:
-          name: deploy
-          context: global_nonprod
-          requires:
-            - build
+      - silta/drupal-build-deploy:
+          # Extend the build-deploy configuration for the production environment.
+          <<: *build-deploy
+          name: build-deploy-prod
           silta_config: silta/silta.yml,silta/silta-prod.yml
+          context: global_nonprod
           filters:
             branches:
               only: production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  silta: silta/silta@0.1
+  silta: silta/silta@dev:feature/slt-108-skip-unnecessary-builds
 
 workflows:
   version: 2

--- a/.dockerignore
+++ b/.dockerignore
@@ -16,3 +16,4 @@ vendor/**/Tests
 web/sites/**/files
 web/.dockerignore
 Dockerfile
+composer.lock


### PR DESCRIPTION
Merges `build` and `deploy` into a single `drupal-build-deploy` job to ease passing of image build information to deployment step and avoid re-building existing images. 
Story: https://wunder.atlassian.net/browse/SLT-108