### PR TITLE
Remove wunderio/drupal-ping, follow-up for #25.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
         "vlucas/phpdotenv": "^2.4",
         "webflo/drupal-finder": "^1.0.0",
         "webmozart/path-util": "^2.3",
-        "wunderio/drupal-ping": "^1.0",
         "zaporylie/composer-drupal-optimizations": "^1.1"
     },
     "require-dev": {


### PR DESCRIPTION
@floretan at https://github.com/wunderio/drupal-project/pull/24#issuecomment-473455163: 

> That plugin was used for _ping.php, which is not useful in a kubernetes setup. Rather than adding the dependency, we should remove that configuration.