### PR TITLE
Update Lando to 3.0.0-RC.2+.

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -1,9 +1,6 @@
 name: Silta
 recipe: drupal8
 
-compose:
-  - docker-compose.yml
-
 config:
   webroot: web
   via: nginx
@@ -20,16 +17,24 @@ tooling:
       - "--env=lando"
 
 services:
+  appserver:
+    overrides:
+      environment:
+        HASH_SALT: notsosecurehash
+  # chrome:
+  #   type: compose
+  #   services:
+  #     image: selenium/standalone-chrome
+  #     user: root
+  #     ports:
+  #       - "4444:4444"
+  #     volumes:
+  #       - /dev/shm:/dev/shm
+  #     command: /opt/bin/entry_point.sh
   mailhog:
     type: mailhog
     hogfrom:
       - appserver
-
-  appserver:
-    overrides:
-      services:
-        environment:
-          HASH_SALT: notsosecurehash
 
 proxy:
   mailhog:

--- a/lando-docker-compose.yml
+++ b/lando-docker-compose.yml
@@ -1,8 +1,0 @@
-version: '2'
-services:
-#  chrome:
-#    image: selenium/standalone-chrome
-#    volumes:
-#      - /dev/shm:/dev/shm
-#    ports:
-#      - "4444:4444"


### PR DESCRIPTION
Steps to update to Lando 3.0.0-RC.2+:

1. `lando db-export` - export your local database
2. `lando destroy`
3. `lando poweroff`
4. apply changes in this PR
5. delete `~/.lando` folder
6. `lando start`
7. `lando db-import { dump created in a step 1. }`

Update docs: https://docs.devwithlando.io/guides/updating-to-rc2.html