### PR TITLE
Add npm to Lando tooling (fixes #40).

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -15,17 +15,12 @@ tooling:
     cmd:
       - ./vendor/bin/codecept
       - "--env=lando"
-  npm:
-    description: Runs npm commands
-    service: node
   yarn:
     description: Runs Yarn commands
     service: node
 
 services:
   appserver:
-    build:
-      - composer install
     overrides:
       environment:
         HASH_SALT: notsosecurehash
@@ -46,9 +41,7 @@ services:
   node:
     type: node:10
     build:
-      # Uncomment preferable tool for installing dependencies 
-      # - yarn install
-      # - npm install
+      - yarn install
 
 proxy:
   mailhog:

--- a/.lando.yml
+++ b/.lando.yml
@@ -15,8 +15,8 @@ tooling:
     cmd:
       - ./vendor/bin/codecept
       - "--env=lando"
-  yarn:
-    description: Runs Yarn commands
+  npm:
+    description: Runs npm commands
     service: node
 
 services:
@@ -39,9 +39,9 @@ services:
     hogfrom:
       - appserver
   node:
-    type: node:10
+    type: node
     build:
-      - yarn install
+      - npm install
 
 proxy:
   mailhog:

--- a/.lando.yml
+++ b/.lando.yml
@@ -24,6 +24,8 @@ tooling:
 
 services:
   appserver:
+    build:
+      - composer install
     overrides:
       environment:
         HASH_SALT: notsosecurehash

--- a/.lando.yml
+++ b/.lando.yml
@@ -15,6 +15,12 @@ tooling:
     cmd:
       - ./vendor/bin/codecept
       - "--env=lando"
+  npm:
+    description: Runs npm commands
+    service: node
+  yarn:
+    description: Runs Yarn commands
+    service: node
 
 services:
   appserver:
@@ -35,6 +41,12 @@ services:
     type: mailhog
     hogfrom:
       - appserver
+  node:
+    type: node:10
+    build:
+      # Uncomment preferable tool for installing dependencies 
+      # - yarn install
+      # - npm install
 
 proxy:
   mailhog:

--- a/README.md
+++ b/README.md
@@ -21,3 +21,21 @@ Have a look at the file for details, but in short this is how it works:
 - Create a custom docker image for Drupal and nginx, and push those to a docker registry (typically that of your cloud provider).
 - Install or update our helm chart while passing our custom images as parameters.
 - The helm chart executes the usual drush deployment commands.
+
+## Local development
+
+Quick start: install [Lando](https://docs.devwithlando.io/), add your project's name to `.lando.yml` and run `lando start`.
+
+### Useful commands
+
+- `lando` - Complete list of available Lando [commands](https://docs.devwithlando.io/cli/usage.html).
+- `lando info` - Info about running [services](https://docs.devwithlando.io/config/services.html). More details are available using `--deep` flag.
+- `lando logs -s <service>` - Show service's [logs](https://docs.devwithlando.io/cli/logs.html).
+- `lando drush si --existing-config` - Install Drupal 8 site from [existing configuration](https://www.drupal.org/node/2897299).
+
+### Frontend tools
+
+- Yarn: `lando yarn <parameters>`
+- npm: `lando npm <parameters>`
+
+Activate preferable tool for automatic installation of dependencies by uncommenting your selection at `.lando.yml` > `services:node:build`.

--- a/README.md
+++ b/README.md
@@ -32,10 +32,4 @@ Quick start: install [Lando](https://docs.devwithlando.io/), add your project's 
 - `lando info` - Info about running [services](https://docs.devwithlando.io/config/services.html). More details are available using `--deep` flag.
 - `lando logs -s <service>` - Show service's [logs](https://docs.devwithlando.io/cli/logs.html).
 - `lando drush si --existing-config` - Install Drupal 8 site from [existing configuration](https://www.drupal.org/node/2897299).
-
-### Frontend tools
-
-- Yarn: `lando yarn <parameters>`
-- npm: `lando npm <parameters>`
-
-Activate preferable tool for automatic installation of dependencies by uncommenting your selection at `.lando.yml` > `services:node:build`.
+- `lando yarn <command>` - Use Yarn.

--- a/README.md
+++ b/README.md
@@ -25,11 +25,3 @@ Have a look at the file for details, but in short this is how it works:
 ## Local development
 
 Quick start: install [Lando](https://docs.devwithlando.io/), add your project's name to `.lando.yml` and run `lando start`.
-
-### Useful commands
-
-- `lando` - Complete list of available Lando [commands](https://docs.devwithlando.io/cli/usage.html).
-- `lando info` - Info about running [services](https://docs.devwithlando.io/config/services.html). More details are available using `--deep` flag.
-- `lando logs -s <service>` - Show service's [logs](https://docs.devwithlando.io/cli/logs.html).
-- `lando drush si --existing-config` - Install Drupal 8 site from [existing configuration](https://www.drupal.org/node/2897299).
-- `lando yarn <command>` - Use Yarn.


### PR DESCRIPTION
## Features

- Adds `node` service with [Lando default version](https://docs.devwithlando.io/tutorials/node.html#supported-versions) (currently 10). 
- Adds `lando npm` tool.
- Adds automatic `npm install` at build time.