### PR TITLE
Add composer install to build step.

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -18,6 +18,8 @@ tooling:
 
 services:
   appserver:
+    build:
+      - composer install
     overrides:
       environment:
         HASH_SALT: notsosecurehash


### PR DESCRIPTION
## Features

- Runs `composer install` automatically at every rebuild to keep consistency between `composer.json` and `composer.lock`. 

Another option would be to use `composer validate --no-check-all --strict`.