### PR TITLE
Use php 7.2 by default.

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -4,7 +4,7 @@ recipe: drupal8
 config:
   webroot: web
   via: nginx
-  php: '7.1'
+  php: '7.2'
   database: mariadb:10.2
   #xdebug: true
 


### PR DESCRIPTION
The lando image that gets loaded when php 7.1 is selected points to a debian repository which has been deprecated. Also, as php 7.1 is reaching end of life it's a natural move to stop using it.