### PR TITLE
Fix vlucas/phpdotenv (broken after update to 3.3).

### DIFF
--- a/load.environment.php
+++ b/load.environment.php
@@ -11,7 +11,7 @@ use Dotenv\Exception\InvalidPathException;
 /**
  * Load any .env file. See /.env.example.
  */
-$dotenv = new Dotenv(__DIR__);
+$dotenv = Dotenv::create(__DIR__);
 try {
   $dotenv->load();
 }


### PR DESCRIPTION
# Problem

Site builder is broken after #47. `lando start` > URL gives following error on fresh site:

```
Fatal error: Uncaught TypeError: Argument 1 passed to Dotenv\Dotenv::__construct() must be an instance of Dotenv\Loader, string given, called in /app/load.environment.php on line 14 and defined in /app/vendor/vlucas/phpdotenv/src/Dotenv.php:31 Stack trace: #0 /app/load.environment.php(14): Dotenv\Dotenv->__construct('/app') #1 /app/vendor/composer/autoload_real.php(66): require('/app/load.envir...') #2 /app/vendor/composer/autoload_real.php(56): composerRequire599efd37580279d6a016b0ec99c4e8aa('b31eeea3e696c9a...', '/app/vendor/com...') #3 /app/vendor/autoload.php(7): ComposerAutoloaderInit599efd37580279d6a016b0ec99c4e8aa::getLoader() #4 /app/web/autoload.php(17): require('/app/vendor/aut...') #5 /app/web/index.php(14): require_once('/app/web/autolo...') #6 {main} thrown in /app/vendor/vlucas/phpdotenv/src/Dotenv.php on line 31
```

# Solution

Fix upgrade vlucas/phpdotenv V2 to V3: https://github.com/vlucas/phpdotenv/blob/master/UPGRADING.md