### PR TITLE
Remove outdated example and fix application root

### DIFF
--- a/silta/nginx.Dockerfile
+++ b/silta/nginx.Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for building nginx.
 FROM wunderio/drupal-nginx:v0.1
 
-COPY . /var/www/html/web
+COPY . /app/web
 

--- a/silta/php.Dockerfile
+++ b/silta/php.Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for the Drupal container.
 FROM wunderio/drupal-php-fpm:v0.1
 
-COPY --chown=www-data:www-data . /var/www/html
+COPY --chown=www-data:www-data . /app
 

--- a/silta/shell.Dockerfile
+++ b/silta/shell.Dockerfile
@@ -1,4 +1,4 @@
 # Dockerfile for the Drupal container.
 FROM wunderio/drupal-shell:v0.1
 
-COPY --chown=www-data:www-data . /var/www/html
+COPY --chown=www-data:www-data . /app


### PR DESCRIPTION
The way volumes are specified in silta.yml is now more flexible, and the given example
does not work anymore. See https://github.com/wunderio/charts/blob/master/drupal/values.yaml 
for an example of adding a volume for private files.

The application root within the container is now /app, it is more consistent across different 
types of applications and is also commonly used by other container-based hosting providers.

This pull request was created with https://github.com/wunderio/internal-mass-updater.