### PR TITLE
SDG-1: Enable ports 9200 & 5601 for localhost endpoints, fixes #55.

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -36,7 +36,7 @@ services:
   #     command: /opt/bin/entry_point.sh
   # elasticsearch:
   #   type: elasticsearch:7
-  #   portforward: true
+  #   portforward: "9200"
   #   mem: 1026m
   #   # Install `analysis-icu` plugin after ES service boots up.
   #   run_as_root:

--- a/.lando.yml
+++ b/.lando.yml
@@ -48,7 +48,7 @@ services:
   #       - elasticsearch
   #     image: blacktop/kibana:7
   #     ports:
-  #       - "5601"
+  #       - "5601:5601"
   #   type: compose
   mailhog:
     type: mailhog


### PR DESCRIPTION
This PR enables port 9200 for ES endpoints:
- http://localhost:9200/
- http://es.lndo.site:9200/

and port 5601 for Kibana endpoints:
- http://localhost:5601/
- http://kibana.lndo.site:5601/