### PR TITLE
Remove the Drupal console

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,6 @@
         "composer/installers": "^1.2",
         "cweagans/composer-patches": "^1.6.5",
         "drupal-composer/drupal-scaffold": "^2.5",
-        "drupal/console": "^1.0.2",
         "drupal/core": "^8.7.0",
         "drush/drush": "^9.0.0",
         "webflo/drupal-finder": "^1.0.0",


### PR DESCRIPTION
We don't use it and it generates validation errors.