### PR TITLE
Add elasticsearch.yml template.

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -39,6 +39,8 @@ services:
   #     command: /elastic-entrypoint.sh elasticsearch
   #     ports: 
   #       - "9200:9200"
+  #     volumes:
+  #       - ./.lando/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
   #   # Install ES requirement JDK here & set JAVA_HOME at `.lando/.env`
   #   build_as_root:
   #     - apk --no-cache add openjdk11

--- a/.lando/.env
+++ b/.lando/.env
@@ -1,3 +1,2 @@
-# Elasticsearch service
-JAVA_HOME=/usr/lib/jvm/default-jvm
-ES_JAVA_OPTS=-Xms512m -Xmx512m
+# Set JAVA_HOME for Elasticsearch service
+# JAVA_HOME=/usr/lib/jvm/default-jvm

--- a/.lando/elasticsearch.yml
+++ b/.lando/elasticsearch.yml
@@ -1,0 +1,12 @@
+network.host: 0.0.0.0
+
+# this value is required because we set "network.host"
+# be sure to modify it appropriately for a production cluster deployment
+discovery.zen.minimum_master_nodes: 1
+# bootstrap.memory_lock: true
+
+node.master: true
+node.ingest: true
+node.data: true
+
+discovery.type: "single-node"

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ silta_config: silta/silta.yml,silta/secrets
 ### [Services](https://docs.lando.dev/config/services.html)
 
 - `chrome` - uses [selenium/standalone-chrome](https://hub.docker.com/r/selenium/standalone-chrome/) image, uncomment the service definition at `.lando.yml` to enable.
-- `elasticsearch` - uses [blacktop/elasticsearch:7](https://github.com/blacktop/docker-elasticsearch-alpine) image. Uncomment the service and proxy definitions at `.lando.yml` and `JAVA_HOME` variable at `.lando/.env` to enable the corresponding services. You can change default ES settings at `.lando/elasticsearch.yml`.
+- `elasticsearch` - uses [blacktop/elasticsearch:7](https://github.com/blacktop/docker-elasticsearch-alpine) image. Uncomment the service and proxy definitions at `.lando.yml` and `JAVA_HOME` variable at `.lando/.env` to enable. You can change default ES settings at `.lando/elasticsearch.yml`.
 - `kibana`  - uses [blacktop/kibana:7](https://github.com/blacktop/docker-kibana-alpine) image, uncomment the service and proxy definitions at `.lando.yml` to enable.
 - `mailhog` - uses Lando [MailHog service](https://docs.lando.dev/config/mailhog.html).
 - `node` - uses Lando [Node service](https://docs.lando.dev/config/node.html).

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ silta_config: silta/silta.yml,silta/secrets
 ### [Services](https://docs.lando.dev/config/services.html)
 
 - `chrome` - uses [selenium/standalone-chrome](https://hub.docker.com/r/selenium/standalone-chrome/) image, uncomment the service definition at `.lando.yml` to enable.
-- `elasticsearch` - uses [blacktop/elasticsearch:7](https://github.com/blacktop/docker-elasticsearch-alpine) image, uncomment the service and proxy definitions at `.lando.yml` to enable.
+- `elasticsearch` - uses [blacktop/elasticsearch:7](https://github.com/blacktop/docker-elasticsearch-alpine) image. Uncomment the service and proxy definitions at `.lando.yml` and `JAVA_HOME` variable at `.lando/.env` to enable the corresponding services. You can change default ES settings at `.lando/elasticsearch.yml`.
 - `kibana`  - uses [blacktop/kibana:7](https://github.com/blacktop/docker-kibana-alpine) image, uncomment the service and proxy definitions at `.lando.yml` to enable.
 - `mailhog` - uses Lando [MailHog service](https://docs.lando.dev/config/mailhog.html).
 - `node` - uses Lando [Node service](https://docs.lando.dev/config/node.html).


### PR DESCRIPTION
## Changes
- adds default `elasticsearch.yml` and mounts it to service at build time
- disables `JAVA_HOME` by default
- updates readme

re: https://wunder.slack.com/archives/C3DHJE0S1/p1568975459053700