### PR TITLE
Fix lando start not working, support for case-sensitive filesystems

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -1,4 +1,4 @@
-name: Silta
+name: silta
 recipe: drupal8
 
 config:


### PR DESCRIPTION
By changing this to underscore "silta", it will try to read cache files properly in case-sensitive filesystems such as in Linux or certain FS's in MacOS too.

This problem occured during lando start command:
```
$ lando start
Unhandled rejection Error: There was a problem with parsing /home/miksu/.lando/cache/Silta.tooling.cache. Ensure it is valid JSON! Error: ENOENT: no such file or directory, open '/home/miksu/.lando/cache/Silta.tooling.cache'
    at loadCacheFile (/snapshot/lando/build/cli/lib/bootstrap.js:0:0)
    at Object.exports.getTasks (/snapshot/lando/build/cli/lib/bootstrap.js:0:0)
    at lando.bootstrap.then.lando.getApp.init.then (/snapshot/lando/build/cli/bin/lando.js:0:0)
From previous event:
    at lando.bootstrap.then.lando (/snapshot/lando/build/cli/bin/lando.js:0:0)
    at runCallback (timers.js:696:18)
    at tryOnImmediate (timers.js:667:5)
    at processImmediate (timers.js:649:5)
From previous event:
    at Object.<anonymous> (/snapshot/lando/build/cli/bin/lando.js:0:0)
    at Module._compile (pkg/prelude/bootstrap.js:1254:22)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:711:10)
    at Module.load (internal/modules/cjs/loader.js:610:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:549:12)
    at Function.Module._load (internal/modules/cjs/loader.js:541:3)
    at Function.Module.runMain (pkg/prelude/bootstrap.js:1309:12)
    at startup (internal/bootstrap/node.js:274:19)
    at bootstrapNodeJSCore (internal/bootstrap/node.js:608:3)
```