### PR TITLE
Kubernetes memory units need to be uppercase.

### DIFF
--- a/silta/silta-prod.yml
+++ b/silta/silta-prod.yml
@@ -24,7 +24,7 @@ php:
   resources:
     requests:
       cpu: 200m
-      memory: 256m
+      memory: 256M
 
   # Don't show errors in production.
   errorLevel: "hide"


### PR DESCRIPTION
A lowercase 'm' as the memory unit is interpreted as a zero, which results in no dedicated memory. The change has no effect if your project doesn't have a production branch on Silta, but it's good to prevent future issues.