### PR TITLE
Add tooling for dynamically enabled and disabled xdebug

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -6,7 +6,7 @@ config:
   via: nginx
   php: '7.2'
   database: mariadb:10.2
-  #xdebug: true
+  xdebug: false
 
 tooling:
   grumphp:

--- a/.lando.yml
+++ b/.lando.yml
@@ -16,6 +16,16 @@ tooling:
   npm:
     description: Runs npm commands
     service: node
+  xdebug-on:
+    service: appserver
+    description: Enable xdebug for nginx.
+    cmd: docker-php-ext-enable xdebug && pkill -o -USR2 php-fpm
+    user: root
+  xdebug-off:
+    service: appserver
+    description: Disable xdebug for nginx.
+    cmd: rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && pkill -o -USR2 php-fpm
+    user: root
 
 services:
   appserver:

--- a/.lando.yml
+++ b/.lando.yml
@@ -18,12 +18,12 @@ tooling:
     service: node
   xdebug-on:
     service: appserver
-    description: Enable xdebug for nginx.
+    description: Enables xdebug for nginx
     cmd: docker-php-ext-enable xdebug && pkill -o -USR2 php-fpm
     user: root
   xdebug-off:
     service: appserver
-    description: Disable xdebug for nginx.
+    description: Disables xdebug for nginx
     cmd: rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && pkill -o -USR2 php-fpm
     user: root
 
@@ -49,7 +49,7 @@ services:
   #   services:
   #     image: blacktop/elasticsearch:7
   #     command: /elastic-entrypoint.sh elasticsearch
-  #     ports: 
+  #     ports:
   #       - "9200:9200"
   #     volumes:
   #       - ./.lando/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml

--- a/README.md
+++ b/README.md
@@ -29,4 +29,5 @@ For additional instructions, please see the [Silta documentation](https://github
 
 - `lando` - tools / commands overview.
 - `lando grumphp <commands>` - run [GrumPHP](https://github.com/phpro/grumphp) code quality checks. Modified or new files are checked on git commit, see more at `lando grumphp -h` or [wunderio/code-quality](https://github.com/wunderio/code-quality).
-- `lando npm <commands>` - run npm commands.
+- `lando npm <commands>` - run [npm](https://www.npmjs.com/) commands,
+- `lando xdebug-on`, `lando xdebug-off` - enable / disable [Xdebug](https://xdebug.org/) for [NGINX](https://www.nginx.com/).


### PR DESCRIPTION
# Feature

This adds a tooling for dynamically enabled and disabling xdebug when needed. 
This also allows xdebug to be toggled without the need for rebuild/restart.

See: https://github.com/lando/lando/issues/1668