### PR TITLE
Define JAVA_HOME envvar only for ES service.

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -43,12 +43,15 @@ services:
   #       - "9200:9200"
   #     volumes:
   #       - ./.lando/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
-  #   # Install ES requirement JDK here & set JAVA_HOME at `.lando/.env`
+  #   # Install ES requirement JDK
   #   build_as_root:
   #     - apk --no-cache add openjdk11
   #   # Install `analysis-icu` plugin after ES service boots up
   #   run_as_root:
   #     - elasticsearch-plugin install analysis-icu
+  #   overrides:
+  #     environment:
+  #       JAVA_HOME: /usr/lib/jvm/default-jvm
   # kibana:
   #   type: compose
   #   services:

--- a/.lando/.env
+++ b/.lando/.env
@@ -1,2 +1,2 @@
-# Set JAVA_HOME for Elasticsearch service
-# JAVA_HOME=/usr/lib/jvm/default-jvm
+# Inject additional environment variables into every Lando service
+# @see: https://docs.lando.dev/config/env.html#environment-files


### PR DESCRIPTION
This PR changes the scope of `JAVA_HOME` environment variable to `elasticsearch` service only.