### PR TITLE
Add local Drush site alias, fixes #58.

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -80,7 +80,7 @@ events:
   pre-start:
     - appserver: composer install
   post-db-import:
-    - appserver: cd $LANDO_WEBROOT && drush cr -y
+    - appserver: cd $LANDO_WEBROOT && drush cr -y && drush @local uli
 
 env_file:
   - .lando/.env

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ For additional instructions, please see the [Silta documentation](https://github
 1. Install the latest [Lando](https://github.com/lando/lando/releases) and read the [documentation](https://docs.lando.dev/).
 2. Update your project name and other Lando [Drupal 8 recipe](https://docs.lando.dev/config/drupal8.html)'s parameters at `.lando.yml`.
 3. Run `lando start`.
-4. Import the database `lando db-import </path/to/dumpfile>`.
 
 ### [Services](https://docs.lando.dev/config/services.html)
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ For additional instructions, please see the [Silta documentation](https://github
 1. Install the latest [Lando](https://github.com/lando/lando/releases) and read the [documentation](https://docs.lando.dev/).
 2. Update your project name and other Lando [Drupal 8 recipe](https://docs.lando.dev/config/drupal8.html)'s parameters at `.lando.yml`.
 3. Run `lando start`.
+4. Import the database `lando db-import </path/to/dumpfile>`.
 
 ### [Services](https://docs.lando.dev/config/services.html)
 

--- a/drush/sites/self.site.yml
+++ b/drush/sites/self.site.yml
@@ -12,3 +12,7 @@
 #  user: www-admin
 #  root: /path/to/drupal
 #  uri: http://stage.example.com
+
+local:
+  root: ${env.LANDO_WEBROOT}
+  uri: https://${env.LANDO_APP_PROJECT}.${env.LANDO_DOMAIN}


### PR DESCRIPTION
This PR fixes #58:
- adds local site alias using Lando envvars,
- adds `drush @local uli` command to `post-db-import` event to automatically generate correct Drupal login URL after `lando db-import <dumpfile>`.