### PR TITLE
Update Drush to 10, fixes #92.

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -80,7 +80,7 @@ events:
   pre-start:
     - appserver: composer install
   post-db-import:
-    - appserver: cd $LANDO_WEBROOT && drush cr -y && drush @local uli
+    - appserver: cd $LANDO_WEBROOT && drush cache:rebuild -y && drush @local user:login
 
 env_file:
   - .lando/.env

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "drupal/core-composer-scaffold": "^8.8.0",
         "drupal/simplei": "^1.0",
         "drupal/warden": "^2.0",
-        "drush/drush": "^9.0.0",
+        "drush/drush": "^9.7.1 || ^10.0.0",
         "vlucas/phpdotenv": "^4.0",
         "webflo/drupal-finder": "^1.0.0"
     },


### PR DESCRIPTION
Drush 9+10 combo from upstream: https://github.com/drupal-composer/drupal-project/pull/522/commits/758113b7bb88af9b272774d2120799bace41793d

re: https://wunder.slack.com/archives/CJQRKKY8N/p1576071134049400

Drush 10 is a prerequisite for using the new Drupal [Exclude API](https://www.drupal.org/node/3079028), see release log: https://github.com/drush-ops/drush/releases/tag/10.0.0.