### PR TITLE
Add tooling for enabling/disabling xdebug profiler

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -26,6 +26,16 @@ tooling:
     description: Disables xdebug for nginx
     cmd: rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && pkill -o -USR2 php-fpm
     user: root
+  xdebug-profiler-on:
+    service: appserver
+    description: Enable xdebug profiler.
+    cmd: echo "xdebug.profiler_enable = 1\\nxdebug.profiler_output_dir = /app" >> /usr/local/etc/php/conf.d/xxx-lando-default.ini && pkill -o -USR2 php-fpm
+    user: root
+  xdebug-profiler-off:
+    service: appserver
+    description: Disable xdebug profiler.
+    cmd: pkill -o -USR2 php-fpm && cp /usr/local/etc/php/conf.d/xxx-lando-default.ini /tmp/lando.ini && sed -i '/xdebug\.profiler/d' /tmp/lando.ini && cp /tmp/lando.ini /usr/local/etc/php/conf.d/xxx-lando-default.ini
+    user: root
 
 services:
   appserver:

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ For additional instructions, please see the [Silta documentation](https://github
 - `lando grumphp <commands>` - run [GrumPHP](https://github.com/phpro/grumphp) code quality checks. Modified or new files are checked on git commit, see more at `lando grumphp -h` or [wunderio/code-quality](https://github.com/wunderio/code-quality).
 - `lando npm <commands>` - run [npm](https://www.npmjs.com/) commands.
 - `lando xdebug-on`, `lando xdebug-off` - enable / disable [Xdebug](https://xdebug.org/) for [nginx](https://nginx.org/en/).
+- `lando xdebug-profiler-on`, `lando xdebug-profiler-off` - enable/disable the [Xdebug profiler](https://xdebug.org/docs/profiler). This requires `xdebug-on` to be executed first.
 
 ### Drupal development hints
 


### PR DESCRIPTION
### Feature

This adds a tooling which allows developers to easily enable and disable the xdebug profiler when needed. 

The profiler generates `cachegrind.out.` files in the /app directory which could be loaded to KCacheGrind (and similar) application for further analysis.

Note that this requires a working xdebug setup and assumes that xdebug is enabled (see `lando xdebug-on`)

Usage:
`lando xdebug-profiler-on`
`lando xdebug-profiler-off`