### PR TITLE
Update Lando to v3.0.0 rrc.5.

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -54,6 +54,8 @@ services:
   #     command: /opt/bin/entry_point.sh
   # elasticsearch:
   #   type: compose
+  #   ssl: true
+  #   sslExpose: false
   #   services:
   #     image: blacktop/elasticsearch:7
   #     command: /elastic-entrypoint.sh elasticsearch
@@ -104,4 +106,4 @@ env_file:
   - .lando/.env
 
 # Tested with Lando version
-version: v3.0.0-rrc.2
+version: v3.0.0-rrc.5

--- a/.lando.yml
+++ b/.lando.yml
@@ -61,6 +61,7 @@ services:
   #     command: /elastic-entrypoint.sh elasticsearch
   #     ports:
   #       - "9200:9200"
+  #       - "9300:9300"
   #     volumes:
   #       - ./.lando/elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
   #   run_as_root:


### PR DESCRIPTION
# Changes

- Turned on `SSL` for `elasticsearch` service to re-enable `https`.
- Added port `9300` to service description.