### PR TITLE
DG-26: Upgrade Drupal project template to Drupal 9.

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -109,4 +109,4 @@ env_file:
   - .lando/.env
 
 # Tested with Lando version
-version: v3.0.0-rrc.5
+version: v3.0.7

--- a/.lando.yml
+++ b/.lando.yml
@@ -1,11 +1,11 @@
 name: silta
-recipe: drupal8
+recipe: drupal9
 
 config:
-  webroot: web
+  php: '7.3'
   via: nginx
-  php: '7.2'
-  database: mariadb:10.2
+  webroot: web
+  database: mariadb:10.3
   xdebug: false
 
 tooling:
@@ -39,6 +39,8 @@ tooling:
 
 services:
   appserver:
+    build:
+      - composer install
     overrides:
       environment:
         HASH_SALT: notsosecurehash
@@ -100,8 +102,6 @@ proxy:
     - mail-silta.lndo.site
 
 events:
-  pre-start:
-    - appserver: composer install
   post-db-import:
     - appserver: cd $LANDO_WEBROOT && drush cache:rebuild -y && drush @local user:login
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ For additional instructions, please see the [Silta documentation](https://github
 ### [Setup](https://docs.lando.dev/basics/installation.html)
 
 1. Install the latest [Lando](https://github.com/lando/lando/releases) and read the [documentation](https://docs.lando.dev/).
-2. Update your project name and other Lando [Drupal 8 recipe](https://docs.lando.dev/config/drupal8.html)'s parameters at `.lando.yml`.
+2. Update your project name and other Lando [Drupal 9 recipe](https://docs.lando.dev/config/drupal9.html)'s parameters at `.lando.yml`.
 3. Run `lando start`.
 
 ### [Services](https://docs.lando.dev/config/services.html)

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "wunderio/drupal-project",
-    "description": "Project template for Drupal 8 projects with composer",
+    "description": "Wunder's template for Drupal 9 projects.",
     "type": "project",
     "license": "GPL-2.0-or-later",
     "authors": [
@@ -16,21 +16,19 @@
         }
     ],
     "require": {
-        "php": ">=7.0.8",
-        "composer/installers": "^1.2",
-        "cweagans/composer-patches": "^1.6.5",
-        "drupal/config_installer": "~1.7",
-        "drupal/core-composer-scaffold": "^8.8.0",
-        "drupal/core-recommended": "^8.8.0",
-        "drupal/simplei": "^1.0",
-        "drupal/warden": "^1.2",
-        "drush/drush": "^9.7.1 || ^10.0.0",
+        "php": ">=7.3",
+        "composer/installers": "^1.8",
+        "cweagans/composer-patches": "^1.6",
+        "drupal/core-composer-scaffold": "^9.0",
+        "drupal/core-recommended": "^9.0",
+        "drupal/simplei": "^1.2",
+        "drush/drush": "^10.0",
         "vlucas/phpdotenv": "^4.0",
-        "webflo/drupal-finder": "^1.0.0"
+        "webflo/drupal-finder": "^1.2"
     },
     "require-dev": {
-        "drupal/core-dev": "^8.8.0",
-        "wunderio/code-quality": "^1.0.3",
+        "drupal/core-dev": "^9.0",
+        "wunderio/code-quality": "^1.0",
         "zaporylie/composer-drupal-optimizations": "^1.1"
     },
     "conflict": {
@@ -49,7 +47,6 @@
         "files": ["load.environment.php"]
     },
     "scripts": {
-        "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
         "pre-install-cmd": [
             "DrupalProject\\composer\\ScriptHandler::checkComposerVersion"
         ],
@@ -66,7 +63,7 @@
     "extra": {
         "drupal-scaffold": {
             "locations": {
-                "web-root": "web/"
+                "web-root": "./web"
             }
         },
         "installer-paths": {


### PR DESCRIPTION
This pull request upgrades project template to Drupal 9. Note that https://www.drupal.org/project/config_installer is deprecated and therefore removed from the template. An alternative is to use `drush site:install --existing-config`, see https://www.drupal.org/node/2897299 for details.

## How to test

- `lando start`
- `lando drush @local site:install minimal` - create an initial site with `minimal` profile
- `lando drush @local uli` - generate login URL
- `lando drush @local cex` - export configuration to `config/sync` folder
- `lando drush @local site:install --existing-config` - reinstall the site using an existing configuration.

## Todo:
- Readd Warden module after it's compatible with Drupal 9. Initial patch for Warden 1.x (created by bot): https://www.drupal.org/project/warden/issues/3149333. This doesn't stop accepting/merging the current work, I've opened a separate ticket for it: https://wunder.atlassian.net/browse/DG-27.