### PR TITLE
Upgrade vlucas/phpdotenv to ^5.0.

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -109,4 +109,4 @@ env_file:
   - .lando/.env
 
 # Tested with Lando version
-version: v3.0.7
+version: v3.0.9

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "drupal/core-recommended": "^9.0",
         "drupal/simplei": "^1.2",
         "drush/drush": "^10.0",
-        "vlucas/phpdotenv": "^4.0",
+        "vlucas/phpdotenv": "^5.0",
         "webflo/drupal-finder": "^1.2"
     },
     "require-dev": {

--- a/load.environment.php
+++ b/load.environment.php
@@ -17,4 +17,4 @@ use Dotenv\Dotenv;
  * in the $_ENV and $_SERVER super-globals: "$username = $_ENV['USERNAME'];".
  */
 $dotenv = Dotenv::createImmutable(__DIR__);
-$dotenv->load();
+$dotenv->safeLoad();

--- a/load.environment.php
+++ b/load.environment.php
@@ -11,7 +11,10 @@
 use Dotenv\Dotenv;
 
 /**
- * Load any .env file. See /.env.example.
+ * Load any .env file.
+ *
+ * See /.env.example. All of the defined variables are available
+ * in the $_ENV and $_SERVER super-globals: "$username = $_ENV['USERNAME'];".
  */
 $dotenv = Dotenv::createImmutable(__DIR__);
-$dotenv->safeLoad();
+$dotenv->load();


### PR DESCRIPTION
Using `load()` for `dotenv` assumes there's an `.env` file and throws an error in CI if not. Kept using `safeLoad()` for that reason.