### PR TITLE
Exclude JS files from PHP Code sniffer configuration

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -23,6 +23,9 @@
     <!-- exclude minified files -->
     <exclude-pattern>*.min.*</exclude-pattern>
 
+    <!-- exclude JavaScript files -->
+    <exclude-pattern>*.js</exclude-pattern>
+    
     <!-- exclude third-party node modules -->
     <exclude-pattern>node_modules/</exclude-pattern>
 


### PR DESCRIPTION
Because PHP Code sniffer is not up-to-date with ES6 standards:

_PHP_CodeSniffer does not support modern JS syntax. All JS functionality will be removed in version 4 and no bugs will be fixed in version 3. I strongly suggest switching to a dedicated JS linting tool like eslint._
https://github.com/squizlabs/PHP_CodeSniffer/issues/2785

and already has been disabled in other Wunder projects.

We have a better way of linting JS files, after we merge this https://github.com/wunderio/drupal-project/pull/111 