### PR TITLE
Fix uri for local drush alias

### DIFF
--- a/drush/sites/self.site.yml
+++ b/drush/sites/self.site.yml
@@ -15,4 +15,4 @@
 
 local:
   root: ${env.LANDO_WEBROOT}
-  uri: https://${env.LANDO_APP_PROJECT}.${env.LANDO_DOMAIN}
+  uri: https://${env.LANDO_APP_NAME}.${env.LANDO_DOMAIN}


### PR DESCRIPTION
**Changes proposed**

- Use `LANDO_APP_NAME` rather than `LANDO_APP_PROJECT` in the `drush/sites/self.site.yml` file

**Motivation**

`LANDO_APP_PROJECT` strips away dashes, causing the drush alias uri to be incorrect if the app name includes dashes, like "my-project".

Running `lando drush site-alias` **before** this change

```
$ lando drush site-alias
'@self.local':
  root: /app/web
  uri: 'https://myproject.lndo.site'
  env:
    LANDO_WEBROOT: /app/web
    LANDO_APP_PROJECT: myproject
    LANDO_DOMAIN: lndo.site
```

And running `lando drush site-alias` **after** this change

```
$ lando drush site-alias
'@self.local':
  root: /app/web
  uri: 'https://my-project.lndo.site'
  env:
    LANDO_WEBROOT: /app/web
    LANDO_APP_PROJECT: my-project
    LANDO_DOMAIN: lndo.site
```
