### PR TITLE
Place potencial basicauth settings under one nginx section

### DIFF
--- a/silta/silta-prod.yml
+++ b/silta/silta-prod.yml
@@ -13,11 +13,6 @@ referenceData:
 backup:
   enabled: true
 
-# Uncomment these lines to disable basic auth protection.
-#nginx:
-# basicauth:
-#   enabled: false
-
 php:
   # Reserve more resources for our PHP containerss.
   resources:
@@ -33,6 +28,9 @@ nginx:
     requests:
       cpu: 50m
       memory: 50M
+# Uncomment these lines to disable basic auth protection.
+# basicauth:
+#   enabled: false
 
 # Connect to an externally hosted database.
 #  env:


### PR DESCRIPTION
This caused an issue when I wasn't able to disable basic auth for production on Silta. By moving everything under one nginx section, basic auth was disabled. 
Also this would look better in general. 