### PR TITLE
PSW-10: Unify eslint config syntax and extensions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,7 +15,7 @@
     "Drupal": true
   },
   "rules": {
-    "strict": 0,
+    "strict": "off",
     "prettier/prettier": "error"
   }
 }


### PR DESCRIPTION
https://wunder.atlassian.net/browse/PSW-10

**Unifying config syntax**

We agreed previously to use the string format when defining linting rules. As you can see from changed files, there was just one line which needed updating.

**Unifying file extensions**

All the linting config files are already defined as .json (e.g: `.eslint.json`), and we agreed previously that there is no need to change that.