### PR TITLE
Replacing docker hub images with equivalent hosted on gcr

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,18 @@ version: 2.1
 orbs:
   silta: silta/silta@0.1
 
+executors:
+  cicd73:
+    docker:
+      - image: eu.gcr.io/silta-images/cicd:circleci-php7.3-node12-composer1-v0.1
+
 workflows:
   version: 2
   commit:
     jobs:
       - silta/drupal-validate:
           name: validate
+          executor: cicd73
           post-validation:
             - run: echo "You can add additional validation here!"
 
@@ -19,6 +25,7 @@ workflows:
 
       - silta/drupal-build-deploy: &build-deploy
           name: build-deploy
+          executor: cicd73
           codebase-build:
             - silta/drupal-composer-install
             - silta/npm-install-build

--- a/silta/nginx.Dockerfile
+++ b/silta/nginx.Dockerfile
@@ -1,5 +1,5 @@
-# Dockerfile for building nginx.
-FROM wunderio/drupal-nginx:v0.1
+# Dockerfile for the Nginx container.
+FROM eu.gcr.io/silta-images/nginx:latest
 
 COPY . /app/web
 

--- a/silta/php.Dockerfile
+++ b/silta/php.Dockerfile
@@ -1,5 +1,5 @@
-# Dockerfile for the Drupal container.
-FROM wunderio/drupal-php-fpm:v0.1
+# Dockerfile for the PHP container.
+FROM eu.gcr.io/silta-images/php:7.3-fpm-v0.1
 
 COPY --chown=www-data:www-data . /app
 

--- a/silta/shell.Dockerfile
+++ b/silta/shell.Dockerfile
@@ -1,4 +1,4 @@
-# Dockerfile for the Drupal container.
-FROM wunderio/drupal-shell:v0.1
+# Dockerfile for the Shell container.
+FROM eu.gcr.io/silta-images/shell:php7.3-v0.1
 
 COPY --chown=www-data:www-data . /app


### PR DESCRIPTION
Replacing docker hub images with google container registry equivalent to avoid hitting docker hub limits. This also allows clearer base image selection and usage.

Image list: https://console.cloud.google.com/gcr/images/silta-images/EU