### PR TITLE
Updated lando config to support Xdebug 3 version

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -18,15 +18,10 @@ tooling:
   npm:
     description: Runs npm commands
     service: node
-  xdebug-on:
-    service: appserver
-    description: Enables xdebug for nginx
-    cmd: docker-php-ext-enable xdebug && pkill -o -USR2 php-fpm
-    user: root
-  xdebug-off:
-    service: appserver
-    description: Disables xdebug for nginx
-    cmd: rm /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini && pkill -o -USR2 php-fpm
+  xdebug:
+    description: Loads Xdebug in the mode defined in the .lando/php.ini file. Run `lando xdebug off` to turn Xdebug off.
+    cmd:
+      - appserver: /app/.lando/xdebug.sh
     user: root
   xdebug-profiler-on:
     service: appserver

--- a/.lando.yml
+++ b/.lando.yml
@@ -7,6 +7,8 @@ config:
   webroot: web
   database: mariadb:10.3
   xdebug: false
+  config:
+    php: .lando/php.ini
 
 tooling:
   grumphp:
@@ -49,6 +51,10 @@ services:
         DB_USER_DRUPAL: drupal9
         DB_PASS_DRUPAL: drupal9
         DB_HOST_DRUPAL: database
+        # Support debugging with XDEBUG 3.
+        XDEBUG_MODE:
+        # Support debugging Drush with XDEBUG 3.
+        PHP_IDE_CONFIG: "serverName=appserver"
   # chrome:
   #   type: compose
   #   services:

--- a/.lando/php.ini
+++ b/.lando/php.ini
@@ -1,0 +1,11 @@
+[PHP]
+xdebug.max_nesting_level = 256
+xdebug.show_exception_trace = 0
+xdebug.collect_params = 0
+; Extra custom Xdebug setting for debug to work in PHPStorm/VSCode.
+xdebug.mode = debug
+xdebug.client_host = ${LANDO_HOST_IP}
+xdebug.client_port = 9003
+; Change from yes to trigger if in VSCode.
+xdebug.start_with_request = yes
+xdebug.log = /tmp/xdebug.log

--- a/.lando/php.ini
+++ b/.lando/php.ini
@@ -1,11 +1,4 @@
 [PHP]
-xdebug.max_nesting_level = 256
-xdebug.show_exception_trace = 0
-xdebug.collect_params = 0
-; Extra custom Xdebug setting for debug to work in PHPStorm/VSCode.
+
+; Valid Xdebug modes: https://xdebug.org/docs/all_settings#mode.
 xdebug.mode = debug
-xdebug.client_host = ${LANDO_HOST_IP}
-xdebug.client_port = 9003
-; Change from yes to trigger if in VSCode.
-xdebug.start_with_request = yes
-xdebug.log = /tmp/xdebug.log

--- a/.lando/xdebug.sh
+++ b/.lando/xdebug.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [ "$#" -ne 1 ]; then
+  docker-php-ext-enable xdebug
+  pkill -o -USR2 php-fpm
+  echo "Xdebug is loaded in the mode defined in the .lando/php.ini file."
+  echo "Valid modes: https://xdebug.org/docs/all_settings#mode."
+else
+  rm -rf /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+  pkill -o -USR2 php-fpm
+  echo "Xdebug is turned off."
+fi

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Listen for XDebug (9003)",
+      "type": "php",
+      "request": "launch",
+      "port": 9003,
+      "log": true,
+      "pathMappings": {
+        "/app/": "${workspaceRoot}/"
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ For additional instructions, please see the [Silta documentation](https://github
 - `lando` - tools / commands overview.
 - `lando grumphp <commands>` - run [GrumPHP](https://github.com/phpro/grumphp) code quality checks. Modified or new files are checked on git commit, see more at `lando grumphp -h` or [wunderio/code-quality](https://github.com/wunderio/code-quality).
 - `lando npm <commands>` - run [npm](https://www.npmjs.com/) commands.
-- `lando xdebug-on`, `lando xdebug-off` - enable / disable [Xdebug](https://xdebug.org/) for [nginx](https://nginx.org/en/).
-- `lando xdebug-profiler-on`, `lando xdebug-profiler-off` - enable/disable the [Xdebug profiler](https://xdebug.org/docs/profiler). This requires `xdebug-on` to be executed first.
+- `lando xdebug` - enable [Xdebug](https://xdebug.org/) in the mode defined in the `.lando/php.ini` file (defaults to `debug`). Run `lando xdebug off` to turn Xdebug off.
+- `lando xdebug-profiler-on`, `lando xdebug-profiler-off` - enable/disable the [Xdebug profiler](https://xdebug.org/docs/profiler). This requires `lando xdebug` to be executed first.
 
 ### Drupal development hints
 


### PR DESCRIPTION
This PR adds support for Xdebug 3 version as PHP 7.2+ uses Xdebug 3.

Updates are based on info provided in the following lando related issue (and tested with Omnia lando setup):
https://github.com/lando/lando/issues/2718
https://github.com/lando/lando/pull/2741/files

With these updates you are able switch xdebug on and off with existing tool commands of `lando xdebug-on` and `lando xdebug-off` as previously with Xdebug 2.