### PR TITLE
Introduce 'lando xdebug <mode>' tool  🎉

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -6,7 +6,7 @@ config:
   via: nginx
   webroot: web
   database: mariadb:10.3
-  xdebug: false
+  xdebug: off
   config:
     php: .lando/php.ini
 
@@ -19,7 +19,7 @@ tooling:
     description: Runs npm commands
     service: node
   xdebug:
-    description: Loads Xdebug in the mode defined in the .lando/php.ini file. Run `lando xdebug off` to turn Xdebug off.
+    description: Loads Xdebug in the selected mode
     cmd:
       - appserver: /app/.lando/xdebug.sh
     user: root

--- a/.lando.yml
+++ b/.lando.yml
@@ -23,16 +23,6 @@ tooling:
     cmd:
       - appserver: /app/.lando/xdebug.sh
     user: root
-  xdebug-profiler-on:
-    service: appserver
-    description: Enable xdebug profiler.
-    cmd: echo "xdebug.profiler_enable = 1\\nxdebug.profiler_output_dir = /app" >> /usr/local/etc/php/conf.d/xxx-lando-default.ini && pkill -o -USR2 php-fpm
-    user: root
-  xdebug-profiler-off:
-    service: appserver
-    description: Disable xdebug profiler.
-    cmd: pkill -o -USR2 php-fpm && cp /usr/local/etc/php/conf.d/xxx-lando-default.ini /tmp/lando.ini && sed -i '/xdebug\.profiler/d' /tmp/lando.ini && cp /tmp/lando.ini /usr/local/etc/php/conf.d/xxx-lando-default.ini
-    user: root
 
 services:
   appserver:

--- a/.lando/php.ini
+++ b/.lando/php.ini
@@ -1,4 +1,2 @@
 [PHP]
 
-; Valid Xdebug modes: https://xdebug.org/docs/all_settings#mode.
-xdebug.mode = debug

--- a/.lando/php.ini
+++ b/.lando/php.ini
@@ -1,2 +1,5 @@
 [PHP]
 
+; Xdebug settings required for PhpStorm.
+xdebug.client_host = ${LANDO_HOST_IP}
+xdebug.start_with_request = yes

--- a/.lando/php.ini
+++ b/.lando/php.ini
@@ -1,5 +1,4 @@
 [PHP]
 
 ; Xdebug settings required for PhpStorm.
-xdebug.client_host = ${LANDO_HOST_IP}
 xdebug.start_with_request = yes

--- a/.lando/xdebug.sh
+++ b/.lando/xdebug.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
 if [ "$#" -ne 1 ]; then
-  docker-php-ext-enable xdebug
-  pkill -o -USR2 php-fpm
-  echo "Xdebug is loaded in the mode defined in the .lando/php.ini file."
+  echo "Xdebuf has been turned off, please use the following syntax: 'lando xdebug <mode>'."
   echo "Valid modes: https://xdebug.org/docs/all_settings#mode."
-else
-  rm -rf /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+  echo xdebug.mode = off > /usr/local/etc/php/conf.d/zzz-lando-xdebug.ini
   pkill -o -USR2 php-fpm
-  echo "Xdebug is turned off."
+else
+  mode="$1"
+  echo xdebug.mode = "$mode" > /usr/local/etc/php/conf.d/zzz-lando-xdebug.ini
+  pkill -o -USR2 php-fpm
+  echo "Xdebug is loaded in "$mode" mode."
 fi

--- a/.lando/xdebug.sh
+++ b/.lando/xdebug.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if [ "$#" -ne 1 ]; then
-  echo "Xdebuf has been turned off, please use the following syntax: 'lando xdebug <mode>'."
+  echo "Xdebug has been turned off, please use the following syntax: 'lando xdebug <mode>'."
   echo "Valid modes: https://xdebug.org/docs/all_settings#mode."
   echo xdebug.mode = off > /usr/local/etc/php/conf.d/zzz-lando-xdebug.ini
   pkill -o -USR2 php-fpm

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,7 @@
       "port": 9003,
       "log": true,
       "pathMappings": {
-        "/app/": "${workspaceRoot}/"
+        "/app/": "${workspaceFolder}/"
       }
     }
   ]

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For additional instructions, please see the [Silta documentation](https://github
 - `lando` - tools / commands overview.
 - `lando grumphp <commands>` - run [GrumPHP](https://github.com/phpro/grumphp) code quality checks. Modified or new files are checked on git commit, see more at `lando grumphp -h` or [wunderio/code-quality](https://github.com/wunderio/code-quality).
 - `lando npm <commands>` - run [npm](https://www.npmjs.com/) commands.
-- `lando xdebug` - load [Xdebug](https://xdebug.org/) in the selected [mode(s)](https://xdebug.org/docs/all_settings#mode). Modes can be defined in the `.lando/php.ini` file, default value is `debug`. Run `lando xdebug off` to turn Xdebug off.
+- `lando xdebug <mode>` - load [Xdebug](https://xdebug.org/) in the selected [mode(s)](https://xdebug.org/docs/all_settings#mode).
 
 ### Drupal development hints
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ For additional instructions, please see the [Silta documentation](https://github
 - `lando` - tools / commands overview.
 - `lando grumphp <commands>` - run [GrumPHP](https://github.com/phpro/grumphp) code quality checks. Modified or new files are checked on git commit, see more at `lando grumphp -h` or [wunderio/code-quality](https://github.com/wunderio/code-quality).
 - `lando npm <commands>` - run [npm](https://www.npmjs.com/) commands.
-- `lando xdebug` - enable [Xdebug](https://xdebug.org/) in the mode defined in the `.lando/php.ini` file (defaults to `debug`). Run `lando xdebug off` to turn Xdebug off.
-- `lando xdebug-profiler-on`, `lando xdebug-profiler-off` - enable/disable the [Xdebug profiler](https://xdebug.org/docs/profiler). This requires `lando xdebug` to be executed first.
+- `lando xdebug` - load [Xdebug](https://xdebug.org/) in the selected [mode(s)](https://xdebug.org/docs/all_settings#mode). Modes can be defined in the `.lando/php.ini` file, default value is `debug`. Run `lando xdebug off` to turn Xdebug off.
 
 ### Drupal development hints
 


### PR DESCRIPTION
There is now ~~`lando xdebug`~~ `lando xdebug <mode>` tool in place via ~~https://github.com/wunderio/drupal-project/pull/176~~ https://github.com/wunderio/drupal-project/pull/178/commits/2a14a84d86388d3dcd4cb4ef09aac3cb15a1394a which can be used for Xdebug `profile` mode as well: `lando xdebug profile`. Therefore, `xdebug-profiler*` tools can be removed.

### Testing

1. run `lando xdebug profile`,
2. turn on profiler in your browser's Xdebug helper plugin,
3. load the site.

Logfile `cachegrind.out.*` can be found at `/tmp/` folder. Run `lando xdebug off` or just `lando xdebug` to load Xdebug in `off` mode.