### PR TITLE
Provide project's drupal version

### DIFF
--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -3,3 +3,6 @@
 #
 # See https://github.com/wunderio/charts/blob/master/drupal/values.yaml
 # for all possible options.
+
+php:
+  drupalCoreVersion: "9"


### PR DESCRIPTION
There might be some functional diferences between drupal versions. The only difference currently is between core 7 and 8+, it includes a different settings.silta.php file.