### PR TITLE
Fix elasticsearch and kibana container versions

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -53,7 +53,7 @@ services:
   # elasticsearch:
   #   type: compose
   #   services:
-  #     image: bitnami/elasticsearch:7
+  #     image: bitnami/elasticsearch:7.10.2
   #     command: /opt/bitnami/scripts/elasticsearch/entrypoint.sh /opt/bitnami/scripts/elasticsearch/run.sh
   #     ports:
   #       - "9200:9200"
@@ -71,7 +71,7 @@ services:
   # kibana:
   #   type: compose
   #   services:
-  #     image: bitnami/kibana:7
+  #     image: bitnami/kibana:7.10.2
   #     ports:
   #       - "5601:5601"
   #     depends_on:


### PR DESCRIPTION
Today a new version of the bitnami container for elasticsearch came out, and our project's lando setup broke with this error message: 


```
elasticsearch_1    | [2021-05-03T08:20:11,283][ERROR][o.e.b.ElasticsearchUncaughtExceptionHandler] [ca089255bac6] uncaught exception in thread [main]
elasticsearch_1    | org.elasticsearch.bootstrap.StartupException: ElasticsearchException[Failure running machine learning native code. This could be due to running on an unsupported OS or distribution, missing OS libraries, or a problem with the temp directory. To bypass this problem by running Elasticsearch without machine learning functionality set [xpack.ml.enabled: false].]
```

Reverting to the previous version of the container for elasticsearch and kibana made it work again. So I suggest to lock the version of the container to more specific versions that have been shown to work correctly.

