### PR TITLE
Add GitHub Codespace support

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.187.0/containers/codespaces-linux/.devcontainer/base.Dockerfile
+
+FROM mcr.microsoft.com/vscode/devcontainers/universal:1-focal
+
+# ** [Optional] Uncomment this section to install additional packages. **
+# USER root
+#
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+#
+# USER codespace
+
+# Install Lando without having docker-ce as hard-dependency
+USER root
+RUN wget https://files.devwithlando.io/lando-stable.deb && dpkg -i --ignore-depends=docker-ce lando-stable.deb && usermod -aG docker codespace
+USER codespace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,53 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.187.0/containers/codespaces-linux
+{
+	"name": "GitHub Codespaces (Default)",
+	"build": {
+		"dockerfile": "Dockerfile"
+	},
+	"settings": {
+		"go.toolsManagement.checkForUpdates": "local",
+		"go.useLanguageServer": true,
+		"go.gopath": "/go",
+		"go.goroot": "/usr/local/go",
+		"python.pythonPath": "/opt/python/latest/bin/python",
+		"python.linting.enabled": true,
+		"python.linting.pylintEnabled": true,
+		"python.formatting.autopep8Path": "/usr/local/py-utils/bin/autopep8",
+		"python.formatting.blackPath": "/usr/local/py-utils/bin/black",
+		"python.formatting.yapfPath": "/usr/local/py-utils/bin/yapf",
+		"python.linting.banditPath": "/usr/local/py-utils/bin/bandit",
+		"python.linting.flake8Path": "/usr/local/py-utils/bin/flake8",
+		"python.linting.mypyPath": "/usr/local/py-utils/bin/mypy",
+		"python.linting.pycodestylePath": "/usr/local/py-utils/bin/pycodestyle",
+		"python.linting.pydocstylePath": "/usr/local/py-utils/bin/pydocstyle",
+		"python.linting.pylintPath": "/usr/local/py-utils/bin/pylint",
+		"lldb.executable": "/usr/bin/lldb",
+		"files.watcherExclude": {
+			"**/target/**": true
+		}
+	},
+	"remoteUser": "codespace",
+	"overrideCommand": false,
+	"mounts": ["source=codespaces-linux-var-lib-docker,target=/var/lib/docker,type=volume"],
+	"runArgs": [
+		"--cap-add=SYS_PTRACE",
+		"--security-opt",
+		"seccomp=unconfined",
+		"--privileged",
+		"--init"
+	],
+	
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"GitHub.vscode-pull-request-github",
+		"dbaeumer.vscode-eslint",
+		"stylelint.vscode-stylelint"
+	],
+	
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// "oryx build" will automatically install your dependencies and attempt to build your project
+	"postCreateCommand": "oryx build -p virtualenv_name=.venv --log-file /tmp/oryx-build.log --manifest-dir /tmp || echo 'Could not auto-build. Skipping.'"
+}


### PR DESCRIPTION
Extended from generic universal linux image having Lando and two additional VSCode extensions:
  - dbaeumer.vscode-eslint
  - stylelint.vscode-stylelint

## Testing
Create codespace from GitHub. Once it's ready, follow local setup instructions (rename your project and run `lando start`). Then search NGINX ports (make sure you set right protocol for the port) and try them out.

### Create codespace
![01-create](https://user-images.githubusercontent.com/93661/129355253-467957e9-952f-464c-b632-7b778c68325e.gif)

### Rename your project
![02-rename](https://user-images.githubusercontent.com/93661/129355264-bdb79dff-8ecc-42d8-bb7a-c599e7817992.gif)

### Start lando
![03-landostart](https://user-images.githubusercontent.com/93661/129355283-5c286309-4b83-45f9-bcc0-09af7f9f6773.gif)

### Access your environment
![04-access-env](https://user-images.githubusercontent.com/93661/129355296-b7dd1593-e4c1-4b24-a5f5-6f4ba0127bca.gif)
