### PR TITLE
Enable development mode on local environment by default

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -1,4 +1,4 @@
-name: silta
+name: drupal-project
 recipe: drupal9
 
 config:
@@ -34,17 +34,22 @@ tooling:
     user: root
 
 services:
+  database:
+    # User random static high port for database connection.
+    portforward: 34567
   appserver:
+    # Install dependencies when building lando.
     build:
       - "composer install"
     overrides:
       environment:
         HASH_SALT: notsosecurehash
-        ENVIRONMENT_NAME: local
+        ENVIRONMENT_NAME: lando
         DB_NAME_DRUPAL: drupal9
         DB_USER_DRUPAL: drupal9
         DB_PASS_DRUPAL: drupal9
         DB_HOST_DRUPAL: database
+        DRUSH_OPTIONS_URI: https://drupal-project.lndo.site
         # Support debugging with XDEBUG 3.
         XDEBUG_MODE:
         PHP_IDE_CONFIG: serverName=appserver
@@ -87,9 +92,9 @@ services:
 
 proxy:
   mailhog:
-    - mail-silta.lndo.site
+    - mail.lndo.site
   # kibana:
-  #   - "kibana-silta.lndo.site:5601"
+  #   - "kibana.lndo.site:5601"
 
 events:
   post-db-import:
@@ -99,4 +104,4 @@ env_file:
   - .lando/.env
 
 # Tested with Lando version
-version: v3.1.4
+version: v3.3.1

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,8 @@
         "composer/installers": "^2.0",
         "cweagans/composer-patches": "^1.7",
         "drupal/admin_toolbar": "^3.0",
-        "drupal/core-composer-scaffold": "^9.1",
-        "drupal/core-recommended": "^9.1",
+        "drupal/core-composer-scaffold": "^9.2",
+        "drupal/core-recommended": "^9.2",
         "drupal/monolog": "^2.0@beta",
         "drupal/simplei": "^1.2",
         "drupal/warden": "^3.0@RC",
@@ -67,6 +67,9 @@
         "drupal-scaffold": {
             "locations": {
                 "web-root": "web/"
+            },
+            "file-mapping": {
+                "[web-root]/sites/development.services.yml": false
             }
         },
         "installer-paths": {

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -21,32 +21,6 @@ $databases['default']['default'] = [
 // Salt for one-time login links, cancel links, form tokens, etc.
 $settings['hash_salt'] = $_ENV['HASH_SALT'];
 
-// Environment-specific settings.
-$env = $_ENV['ENVIRONMENT_NAME'];
-switch ($env) {
-  case 'production':
-    $settings['simple_environment_indicator'] = '#9E005D Production';
-    // Warden settings.
-    $config['warden.settings']['warden_token'] = $_ENV['WARDEN_TOKEN'];
-    break;
-
-  case 'master':
-    $settings['simple_environment_indicator'] = '#5B37BF Stage';
-    break;
-
-  case 'local':
-    $settings['simple_environment_indicator'] = '#2F2942 Local';
-    // Skip file system permissions hardening.
-    $settings['skip_permissions_hardening'] = TRUE;
-    // Skip trusted host pattern.
-    $settings['trusted_host_patterns'] = ['.*'];
-    break;
-
-  default:
-    $settings['simple_environment_indicator'] = '#2F2942 Test';
-    break;
-}
-
 // Location of the site configuration files.
 $settings['config_sync_directory'] = '../config/sync';
 
@@ -67,6 +41,40 @@ $settings['file_scan_ignore_directories'] = [
   'node_modules',
   'bower_components',
 ];
+
+// Environment-specific settings.
+$env = $_ENV['ENVIRONMENT_NAME'];
+switch ($env) {
+  case 'production':
+    $settings['simple_environment_indicator'] = 'DarkRed Production';
+    // Warden settings.
+    $config['warden.settings']['warden_token'] = $_ENV['WARDEN_TOKEN'];
+    break;
+
+  case 'master':
+    $settings['simple_environment_indicator'] = 'DarkBlue Stage';
+    break;
+
+  case 'local':
+    $settings['simple_environment_indicator'] = 'DarkGreen Local';
+    // Skip file system permissions hardening.
+    $settings['skip_permissions_hardening'] = TRUE;
+    // Skip trusted host pattern.
+    $settings['trusted_host_patterns'] = ['.*'];
+    // Debug mode on lando.
+    $settings['container_yamls'][] = DRUPAL_ROOT . '/sites/development.services.yml';
+    $config['system.performance']['css']['preprocess'] = FALSE;
+    $config['system.performance']['js']['preprocess'] = FALSE;
+    $settings['cache']['bins']['render'] = 'cache.backend.null';
+    $settings['cache']['bins']['dynamic_page_cache'] = 'cache.backend.null';
+    $settings['cache']['bins']['page'] = 'cache.backend.null';
+    $settings['extension_discovery_scan_tests'] = FALSE;
+    break;
+
+  default:
+    $settings['simple_environment_indicator'] = '#2F2942 Test';
+    break;
+}
 
 /**
  * Load local development override configuration, if available.

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -56,6 +56,7 @@ switch ($env) {
     break;
 
   case 'local':
+  case 'lando':
     $settings['simple_environment_indicator'] = 'DarkGreen Local';
     // Skip file system permissions hardening.
     $settings['skip_permissions_hardening'] = TRUE;

--- a/web/sites/development.services.yml
+++ b/web/sites/development.services.yml
@@ -1,0 +1,12 @@
+# Local development services.
+#
+# To activate this feature, follow the instructions at the top of the
+# 'example.settings.local.php' file, which sits next to this file.
+parameters:
+  http.response.debug_cacheability_headers: true
+  twig.config:
+    debug: true
+    auto_reload: true
+services:
+  cache.backend.null:
+    class: Drupal\Core\Cache\NullBackendFactory

--- a/web/sites/development.services.yml
+++ b/web/sites/development.services.yml
@@ -1,7 +1,4 @@
 # Local development services.
-#
-# To activate this feature, follow the instructions at the top of the
-# 'example.settings.local.php' file, which sits next to this file.
 parameters:
   http.response.debug_cacheability_headers: true
   twig.config:


### PR DESCRIPTION
*Enabling of develop mode on local environment: #216*

*Changes proposed in this PR:*
- Add default development services and exclude it from scaffold.
- Add development mode to local environment settings.
- Update Drupal to latest version.
- Make simplei colors more accessible for color blind people. 

*How to test:*
1. Do the basic setup and validate that development mode is enabled locally

