### PR TITLE
Set grumphp test php version to 7.4

### DIFF
--- a/grumphp.yml
+++ b/grumphp.yml
@@ -7,6 +7,7 @@ grumphp:
   tasks:
     php_compatibility:
       run_on: ['web/modules/custom', 'web/themes/custom', 'web/sites']
+      testVersion: '7.4'
     check_file_permissions: ~
     php_check_syntax:
       run_on: ['web/modules/custom', 'web/themes/custom', 'web/sites']


### PR DESCRIPTION
We now have in composer.json the minimum php version set to 7.4, so we should tell grumphp as well, otherwise you will get errors when using php 7.4 features like typed arguments.

![image](https://user-images.githubusercontent.com/185412/143247824-7518d03e-852b-4b3d-950d-43d4732b90a8.png)

