### PR TITLE
Override Silta referenceEnvironment master > main.

### DIFF
--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -6,3 +6,8 @@
 
 php:
   drupalCoreVersion: "9"
+
+# Configure reference data that will be used when creating new environments.
+referenceData:
+  # The name of the environment from which reference data will be copied.
+  referenceEnvironment: 'main'


### PR DESCRIPTION
[Default](https://github.com/wunderio/charts/blob/master/drupal/values.yaml) Silta `referenceEnvironment` is  `master`, but `master` branch is not present anymore after https://github.com/wunderio/drupal-project/commit/0f7e79037f3401ef0f97d9b1b991f54bddfd0965 has been introduced. Therefore, we need to override Silta `referenceEnvironment` value from `master` to `main`.

Blocker here: https://github.com/wunderio/drupal-project/pull/268#issuecomment-1028768476