### PR TITLE
Use official images for Elasticsearch & Kibana in Lando, fixes #277.

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -61,26 +61,36 @@ services:
       image: drupalci/webdriver-chromedriver:production
       command: chromedriver --log-path=/tmp/chromedriver.log --verbose --whitelisted-ips=
   # elasticsearch:
-  #   type: "elasticsearch:7.16.2"
-  #   # Replace `true` with `9200` for proxy http://localhost:9200.
-  #   portforward: true
-  #   overrides:
+  #   type: compose
+  #   services:
+  #     image: "docker.elastic.co/elasticsearch/elasticsearch:7.17.0"
+  #     command: "/bin/tini -- /usr/local/bin/docker-entrypoint.sh eswrapper"
+  #     user: elasticsearch
   #     environment:
-  #       ELASTICSEARCH_HEAP_SIZE: 1024m
-  #       # Allow CORS requests.
+  #       ES_JAVA_OPTS: "-Xms1g -Xmx1g"
+  #       discovery.type: "single-node"
+  #       bootstrap.memory_lock: "true"
   #       http.cors.enabled: "true"
   #       http.cors.allow-origin: "*"
-  #       # Enable Xpack security.
-  #       xpack.security.enabled: "true"
-  #       # Comma, semi-colon or space separated list of plugins to install at initialization.
-  #       ELASTICSEARCH_PLUGINS: analysis-icu
+  #     ulimits:
+  #       memlock:
+  #         soft: "-1"
+  #         hard: "-1"
+  #     ports:
+  #       - "9200:9200"
+  #     volumes:
+  #       - esdata:/usr/share/elasticsearch/data
+  #   volumes:
+  #     esdata:
+  #       driver: local
   # kibana:
   #   type: compose
-  #   ssl: true
-  #   sslExpose: false
   #   services:
-  #     image: "bitnami/kibana:7.16.2"
-  #     command: "/opt/bitnami/scripts/kibana/entrypoint.sh /opt/bitnami/scripts/kibana/run.sh"
+  #     image: "docker.elastic.co/kibana/kibana:7.17.0"
+  #     command: "/bin/tini -- /usr/local/bin/kibana-docker"
+  #     user: kibana
+  #     ports:
+  #       - "5601:5601"
   mailhog:
     type: mailhog
     hogfrom:
@@ -93,8 +103,10 @@ services:
 proxy:
   mailhog:
     - mail.lndo.site
+  # elasticsearch:
+  #   - elasticsearch.lndo.site:9200
   # kibana:
-  #   - "kibana.lndo.site:5601"
+  #   - kibana.lndo.site:5601
 
 events:
   post-db-import:

--- a/.lando.yml
+++ b/.lando.yml
@@ -70,6 +70,7 @@ services:
   #       ES_JAVA_OPTS: "-Xms1g -Xmx1g"
   #       discovery.type: "single-node"
   #       bootstrap.memory_lock: "true"
+  #       # Allow CORS requests.
   #       http.cors.enabled: "true"
   #       http.cors.allow-origin: "*"
   #     ulimits:

--- a/.lando.yml
+++ b/.lando.yml
@@ -80,6 +80,7 @@ services:
   #       - "9200:9200"
   #     volumes:
   #       - esdata:/usr/share/elasticsearch/data
+  #       - ./.lando/elasticsearch-plugins.yml:/usr/share/elasticsearch/config/elasticsearch-plugins.yml
   #   volumes:
   #     esdata:
   #       driver: local

--- a/.lando/elasticsearch-plugins.yml
+++ b/.lando/elasticsearch-plugins.yml
@@ -1,0 +1,2 @@
+plugins:
+  - id: analysis-icu

--- a/.lando/elasticsearch-plugins.yml
+++ b/.lando/elasticsearch-plugins.yml
@@ -1,2 +1,3 @@
+# https://www.elastic.co/guide/en/elasticsearch/plugins/current/manage-plugins-using-configuration-file.html
 plugins:
   - id: analysis-icu

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Drush alias for **current** Silta feature branch deployment is `drush @current s
 ## Local environment
 
 - Appserver: <https://drupal-project.lndo.site>
-- Elasticsearch: <http://localhost:9200/>, <http://elasticsearch.lndo.site>
+- Elasticsearch: <http://localhost:9200>, <http://elasticsearch.lndo.site>
 - Kibana: <http://localhost:5601>, <http://kibana.lndo.site>
 - Mailhog: <http://mail.lndo.site>
 - Drush alias: `lando drush @local st`
@@ -41,7 +41,7 @@ Drush alias for **current** Silta feature branch deployment is `drush @current s
 ### [Services](https://docs.lando.dev/config/services.html)
 
 - `chrome` - uses [selenium/standalone-chrome](https://hub.docker.com/r/selenium/standalone-chrome/) image, uncomment the service definition at `.lando.yml` to enable.
-- `elasticsearch` - uses official [Elasticsearch image](https://hub.docker.com/r/elastic/elasticsearch), uncomment the service definition at `.lando.yml` to enable.
+- `elasticsearch` - uses official [Elasticsearch image](https://hub.docker.com/r/elastic/elasticsearch), uncomment the service definition at `.lando.yml` to enable. Requires [at least 4GiB of memory](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html).
 - `kibana`  - uses official [Kibana image](https://hub.docker.com/r/elastic/kibana), uncomment the service definition at `.lando.yml` to enable.
 - `mailhog` - uses Lando [MailHog service](https://docs.lando.dev/config/mailhog.html).
 - `node` - uses Lando [Node service](https://docs.lando.dev/config/node.html).

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Drush alias for **current** Silta feature branch deployment is `drush @current s
 ### [Services](https://docs.lando.dev/config/services.html)
 
 - `chrome` - uses [selenium/standalone-chrome](https://hub.docker.com/r/selenium/standalone-chrome/) image, uncomment the service definition at `.lando.yml` to enable.
-- `elasticsearch` - uses official [Elasticsearch image](https://hub.docker.com/r/elastic/elasticsearch), uncomment the service definition at `.lando.yml` to enable. Requires [at least 4GiB of memory](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html).
+- `elasticsearch` - uses official [Elasticsearch image](https://hub.docker.com/r/elastic/elasticsearch), uncomment the service definition at `.lando.yml` to enable. Requires [at least 4GiB of memory](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html). Use `.lando/elasticsearch-plugins.yml` for plugins management.
 - `kibana`  - uses official [Kibana image](https://hub.docker.com/r/elastic/kibana), uncomment the service definition at `.lando.yml` to enable.
 - `mailhog` - uses Lando [MailHog service](https://docs.lando.dev/config/mailhog.html).
 - `node` - uses Lando [Node service](https://docs.lando.dev/config/node.html).

--- a/README.md
+++ b/README.md
@@ -25,7 +25,10 @@ Drush alias for **current** Silta feature branch deployment is `drush @current s
 
 ## Local environment
 
-- URL: <https://drupal-project.lndo.site>
+- Appserver: <https://drupal-project.lndo.site>
+- Elasticsearch: <http://localhost:9200/>, <http://elasticsearch.lndo.site>
+- Kibana: <http://localhost:5601>, <http://kibana.lndo.site>
+- Mailhog: <http://mail.lndo.site>
 - Drush alias: `lando drush @local st`
 - SSH: `lando ssh (-s <service>)`
 
@@ -38,8 +41,8 @@ Drush alias for **current** Silta feature branch deployment is `drush @current s
 ### [Services](https://docs.lando.dev/config/services.html)
 
 - `chrome` - uses [selenium/standalone-chrome](https://hub.docker.com/r/selenium/standalone-chrome/) image, uncomment the service definition at `.lando.yml` to enable.
-- `elasticsearch` - uses Lando [Elasticsearch service](https://docs.lando.dev/config/elasticsearch.html), uncomment the service definition at `.lando.yml` to enable.
-- `kibana`  - available at <https://kibana-silta.lndo.site>. Uses [bitnami/kibana](https://github.com/bitnami/bitnami-docker-kibana) image, uncomment the service definition at `.lando.yml` to enable.
+- `elasticsearch` - uses official [Elasticsearch image](https://hub.docker.com/r/elastic/elasticsearch), uncomment the service definition at `.lando.yml` to enable.
+- `kibana`  - uses official [Kibana image](https://hub.docker.com/r/elastic/kibana), uncomment the service definition at `.lando.yml` to enable.
 - `mailhog` - uses Lando [MailHog service](https://docs.lando.dev/config/mailhog.html).
 - `node` - uses Lando [Node service](https://docs.lando.dev/config/node.html).
 


### PR DESCRIPTION
*Link to ticket: #277*

*Changes proposed in this PR:*
- Replaced Elasticsearch & Kibana Bitnami images with official ones for `arm64` support.

*How to test:*
1. Follow the readme and enable Elasticsearch & Kibana services.
2. Go to http://localhost:5601/app/dev_tools#/console and run `GET /_cat/plugins`. It should give `analysis-icu 7.17.0` as a response.