### PR TITLE
Change ES plugins install method, fixes #281.

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -67,7 +67,7 @@ services:
   #     command: "/bin/tini -- /usr/local/bin/docker-entrypoint.sh eswrapper"
   #     user: elasticsearch
   #     environment:
-  #       ES_JAVA_OPTS: "-Xms1g -Xmx1g"
+  #       ES_JAVA_OPTS: "-Xms512m -Xmx512m"
   #       discovery.type: "single-node"
   #       bootstrap.memory_lock: "true"
   #       # Allow CORS requests.

--- a/.lando.yml
+++ b/.lando.yml
@@ -81,6 +81,7 @@ services:
   #       - "9200:9200"
   #     volumes:
   #       - esdata:/usr/share/elasticsearch/data
+  #   # Install ES plugins.
   #   build_as_root:
   #     - elasticsearch-plugin install analysis-icu analysis-ukrainian
   #   volumes:

--- a/.lando.yml
+++ b/.lando.yml
@@ -81,7 +81,8 @@ services:
   #       - "9200:9200"
   #     volumes:
   #       - esdata:/usr/share/elasticsearch/data
-  #       - ./.lando/elasticsearch-plugins.yml:/usr/share/elasticsearch/config/elasticsearch-plugins.yml
+  #   build_as_root:
+  #     - elasticsearch-plugin install analysis-icu
   #   volumes:
   #     esdata:
   #       driver: local

--- a/.lando.yml
+++ b/.lando.yml
@@ -82,7 +82,7 @@ services:
   #     volumes:
   #       - esdata:/usr/share/elasticsearch/data
   #   build_as_root:
-  #     - elasticsearch-plugin install analysis-icu
+  #     - elasticsearch-plugin install analysis-icu analysis-ukrainian
   #   volumes:
   #     esdata:
   #       driver: local

--- a/.lando/elasticsearch-plugins.yml
+++ b/.lando/elasticsearch-plugins.yml
@@ -1,3 +1,0 @@
-# https://www.elastic.co/guide/en/elasticsearch/plugins/current/manage-plugins-using-configuration-file.html
-plugins:
-  - id: analysis-icu

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Drush alias for **current** Silta feature branch deployment is `drush @current s
 ### [Services](https://docs.lando.dev/config/services.html)
 
 - `chrome` - uses [selenium/standalone-chrome](https://hub.docker.com/r/selenium/standalone-chrome/) image, uncomment the service definition at `.lando.yml` to enable.
-- `elasticsearch` - uses official [Elasticsearch image](https://hub.docker.com/r/elastic/elasticsearch), uncomment the service definition at `.lando.yml` to enable. Requires [at least 4GiB of memory](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html). Use `.lando/elasticsearch-plugins.yml` for plugins management.
+- `elasticsearch` - uses official [Elasticsearch image](https://hub.docker.com/r/elastic/elasticsearch), uncomment the service definition at `.lando.yml` to enable. Requires [at least 4GiB of memory](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html).
 - `kibana`  - uses official [Kibana image](https://hub.docker.com/r/elastic/kibana), uncomment the service definition at `.lando.yml` to enable.
 - `mailhog` - uses Lando [MailHog service](https://docs.lando.dev/config/mailhog.html).
 - `node` - uses Lando [Node service](https://docs.lando.dev/config/node.html).

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "require-dev": {
         "drupal/core-dev": "^9.3",
         "phpspec/prophecy-phpunit": "^2.0",
-        "wunderio/code-quality": "^2.0"
+        "wunderio/code-quality": "^2.1"
     },
     "conflict": {
         "drupal/drupal": "*"

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -1,3 +1,5 @@
+parameters:
+  grumphp.run_on_paths: ['web/modules/custom', 'web/themes/custom']
 grumphp:
   stop_on_failure: true
   process_timeout: 300
@@ -6,16 +8,16 @@ grumphp:
     succeeded: ~
   tasks:
     php_compatibility:
-      run_on: ['web/modules/custom', 'web/themes/custom', 'web/sites']
+      run_on: '%grumphp.run_on_paths%'
       testVersion: '8.0'
     check_file_permissions: ~
     php_check_syntax:
-      run_on: ['web/modules/custom', 'web/themes/custom', 'web/sites']
+      run_on: '%grumphp.run_on_paths%'
     phpcs:
       standard: ['phpcs.xml']
-      run_on: ['web/modules/custom', 'web/themes/custom']
+      run_on: '%grumphp.run_on_paths%'
     php_stan:
-      run_on: ['web/modules/custom', 'web/themes/custom']
+      run_on: '%grumphp.run_on_paths%'
     yaml_lint: ~
     json_lint: ~
     # PHPUnit will fail with 0 tests.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,4 +1,6 @@
 parameters:
+	# See: https://phpstan.org/config-reference#rule-level
+	level: 2
 	customRulesetUsed: true
 	reportUnmatchedIgnoredErrors: false
 	# Ignore phpstan-drupal extension's rules.
@@ -7,7 +9,6 @@ parameters:
 		- '#Plugin definitions cannot be altered.#'
 		- '#Missing cache backend declaration for performance.#'
 		- '#Plugin manager has cache backend specified but does not declare cache tags.#'
-		- '#Non-namespaced classes/interfaces/traits should not be referenced with use statements#'
 includes:
-	- vendor/mglaman/phpstan-drupal/extension.neon
-	- vendor/phpstan/phpstan-deprecation-rules/rules.neon
+	- %currentWorkingDirectory%/vendor/mglaman/phpstan-drupal/extension.neon
+	- %currentWorkingDirectory%/vendor/phpstan/phpstan-deprecation-rules/rules.neon

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,13 @@
+parameters:
+	customRulesetUsed: true
+	reportUnmatchedIgnoredErrors: false
+	# Ignore phpstan-drupal extension's rules.
+	ignoreErrors:
+		- '#\Drupal calls should be avoided in classes, use dependency injection instead#'
+		- '#Plugin definitions cannot be altered.#'
+		- '#Missing cache backend declaration for performance.#'
+		- '#Plugin manager has cache backend specified but does not declare cache tags.#'
+		- '#Non-namespaced classes/interfaces/traits should not be referenced with use statements#'
+includes:
+	- vendor/mglaman/phpstan-drupal/extension.neon
+	- vendor/phpstan/phpstan-deprecation-rules/rules.neon


### PR DESCRIPTION
*Link to ticket: #281*

*Changes proposed in this PR:*
- change ES plugins install method to fix #281,
- reduce default `ES_JAVA_OPTS` values,
- update wunderio/code-quality to v2.1,
- update readme,
- Slava Ukraini!

*How to test:*
1. Install ES & Kibana with proxies via `lando rebuild`.
2. Perform `lando restart` and confirm that proxies still work.
3. Go to http://localhost:5601/app/dev_tools#/console and run `GET /_cat/plugins`. It should give the list of installed plugins as a response.

Thanks:  @dcorb, @MarttiR, @janmilinds, @hkirsman!