### PR TITLE
Ignore 'Unsafe usage of new static()' warning with PHPStan's analysis level

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -9,6 +9,7 @@ parameters:
 		- '#Plugin definitions cannot be altered.#'
 		- '#Missing cache backend declaration for performance.#'
 		- '#Plugin manager has cache backend specified but does not declare cache tags.#'
+		- '#Unsafe usage of new static\(\)#'
 includes:
 	- %currentWorkingDirectory%/vendor/mglaman/phpstan-drupal/extension.neon
 	- %currentWorkingDirectory%/vendor/phpstan/phpstan-deprecation-rules/rules.neon


### PR DESCRIPTION
If PHPStan level used in code check analysis, there is need to ignore "Usage of new static() errors"

Otherwise checks will report following error each time new Drupal plugin code implemented:

```
Unsafe usage of new static().
         💡 Consider making the class or the constructor final.
```

This is due to fact that standard way to implement \Drupal\Core\DependencyInjection\ContainerInjectionInterface::create() method in Drupal plugin code is as follows:
```

  /**
   * {@inheritdoc}
   */
  public static function create(ContainerInterface $container) {
    return new static(
      $container->get('entity_type.manager')
    );
  }

```

In mglaman/drupal-check this is resolved in the code, but in our case should be taken into account in phpstan.neon

See:
https://github.com/mglaman/drupal-check/issues/136
https://github.com/mglaman/drupal-check/pull/187
https://github.com/mglaman/drupal-check/commit/230b94578fbfda273a52376a205218bffaa90c2a

*How to test:*
1. Create custom module with any Drupal plugin implementation
2. Run code check analysis using grumphp
3. Validate that "Unsafe usage of new static()." errors are ignored

