### PR TITLE
Comment out build-dependabot job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,13 +46,14 @@ workflows:
             branches:
               only: production
 
-      - silta/drupal-build-deploy:
-          <<: *build-deploy
-          name: build-dependabot
-          context: silta_dev
-          skip-deployment: true
-          filters:
-            branches:
-              only: /dependabot\/.*/
+      # This enables validation on dependabot PRs
+      #- silta/drupal-build-deploy:
+      #    <<: *build-deploy
+      #    name: build-dependabot
+      #    context: silta_dev
+      #    skip-deployment: true
+      #    filters:
+      #      branches:
+      #        only: /dependabot\/.*/
 
 


### PR DESCRIPTION
Dependabot PRs usually touch only the composer.lock file, so validation is not likely needed.