### PR TITLE
Add a vim text editor to landofile

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -42,9 +42,10 @@ services:
     # Install dependencies when building lando.
     build:
       - "composer install"
-    build_as_root:
-      - apt update -y
-      - apt install vim -y
+    # Uncomment this if you need to edit files inside the container
+    #build_as_root:
+    #  - apt update -y
+    #  - apt install vim -y
     overrides:
       environment:
         HASH_SALT: notsosecurehash

--- a/.lando.yml
+++ b/.lando.yml
@@ -42,6 +42,9 @@ services:
     # Install dependencies when building lando.
     build:
       - "composer install"
+    build_as_root:
+      - apt update -y
+      - apt install vim -y
     overrides:
       environment:
         HASH_SALT: notsosecurehash


### PR DESCRIPTION
*Changes proposed in this PR:*
- Add a vim text editor to landofile

*Reasoning behind the proposal:*
- a text editor like vim required inside appserver container:
  - in cases when there is need to edit (and import) existing configuration, i.e. lando drush config:edit xyz
  - in cases when there is need to make one-off changes to a file that is located under your excludes (Lando v3.9.x and forward)
     - Excluded files cannot be edited outside of containers.
     - Without text editor there is no way to make one-off changes inside the container and thus, modification of excludes and `lando rebuild` required in order to make one-off change.
