### PR TITLE
#335 Update wunderio/drupal-ping to latest version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "drush/drush": "^11.4",
         "vlucas/phpdotenv": "^5.4",
         "webflo/drupal-finder": "^1.2",
-        "wunderio/drupal-ping": "^2.2"
+        "wunderio/drupal-ping": "^2.4"
     },
     "require-dev": {
         "drupal/core-dev": "^10.0",


### PR DESCRIPTION
[wunderio/](https://packagist.org/packages/wunderio/)drupal-ping was being restricted to older version because it didn't have D10 as requirement. Today this update was released.