### PR TITLE
Configure Google Filestore volume for files storage (2), #323.

### DIFF
--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -14,10 +14,10 @@ referenceData:
 
 # Configure Google Filestore volume for files storage.
 mounts:
-  public-files:
+  public-files-filestore:
     enabled: true
     storage: 10G
-    mountPath: /app/web/sites/default/files
+    mountPath: /app/web/sites/default/files-new
     storageClassName: nfs-shared
   private-files:
     enabled: true

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -20,8 +20,7 @@ mounts:
     mountPath: /app/web/sites/default/files
     storageClassName: nfs-shared
   private-files:
-    # Private files setup is disabled by default.
-    enabled: false
+    enabled: true
     storage: 1G
     mountPath: /app/private
     storageClassName: nfs-shared


### PR DESCRIPTION
Follow-up for https://github.com/wunderio/drupal-project/pull/340. Enables private files mount by default.