### PR TITLE
Add Config Split and Updates Log

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "composer/installers": "^2.1",
         "cweagans/composer-patches": "^1.7",
         "drupal/admin_toolbar": "^3.3",
+        "drupal/config_split": "^2.0@RC",
         "drupal/core-composer-scaffold": "^10.0",
         "drupal/core-recommended": "^10.0",
         "drupal/monolog": "^3.0@beta",
@@ -26,7 +27,8 @@
         "drush/drush": "^11.4",
         "vlucas/phpdotenv": "^5.4",
         "webflo/drupal-finder": "^1.2",
-        "wunderio/drupal-ping": "^2.4"
+        "wunderio/drupal-ping": "^2.4",
+        "wunderio/updates_log": "^2"
     },
     "require-dev": {
         "drupal/core-dev": "^10.0",

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -42,17 +42,28 @@ $settings['file_scan_ignore_directories'] = [
   'bower_components',
 ];
 
+// $settings['updates_log_site'] = 'my-project-name';
+// In Silta it is set by default as github repo name.
+
+// $settings['updates_log_env'] = getenv('ENVIRONMENT_NAME');
+// In Silta it is set by default as ENVIRONMENT_NAME
+
+// $settings['updates_log_disabled'] = TRUE;
+// In case config_split is missing.
+
 // Environment-specific settings.
 $env = $_ENV['ENVIRONMENT_NAME'];
 switch ($env) {
   case 'production':
     $settings['simple_environment_indicator'] = 'DarkRed Production';
-    // Warden settings.
-    $config['warden.settings']['warden_token'] = $_ENV['WARDEN_TOKEN'];
+    // $settings['updates_log_disabled'] = FALSE;
+    // In case config_split is missing.
     break;
 
   case 'main':
     $settings['simple_environment_indicator'] = 'DarkBlue Stage';
+    // $settings['updates_log_disabled'] = FALSE;
+    // In case config_split is missing.
     break;
 
   case 'local':


### PR DESCRIPTION
There is no ticket.
This PR is inspired by the need to integrate the Updates Log, and remove Warden.

*Changes proposed in this PR:*
- Composer:
  - Add: Updates Log
  - Add: Config Split
- Settings:
  - Add: Updates Log
  - Remove: Warden

*How to test:*
1. See if the Config Split is under contrib modules
2. See if the Updates Log is under contrib modules

```
$ ls -lad /app/web/modules/contrib/{config_split,updates_log}
drwxr-xr-x 1 www-data www-data 4096 Sep  3  2022 /app/web/modules/contrib/config_split
drwxr-xr-x 1 www-data www-data 4096 Mar 16 14:13 /app/web/modules/contrib/updates_log
```

*Link to feature environment:*
https://feature-updates-log--and--config-sp769.drupal-project.dev.wdr.io