### PR TITLE
Define a constant instead of duplicating literals

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -39,9 +39,6 @@ tooling:
     user: root
 
 services:
-  database:
-    # User random static high port for database connection.
-    portforward: 34567
   appserver:
     # Install dependencies when building lando.
     build:
@@ -65,6 +62,10 @@ services:
     services:
       image: drupalci/webdriver-chromedriver:production
       command: chromedriver --log-path=/tmp/chromedriver.log --verbose --whitelisted-ips=
+  # Use random static high port for database connection.
+  # @see: https://docs.lando.dev/guides/external-access.html
+  # database:
+  #   portforward: 34567
   # elasticsearch:
   #   type: compose
   #   services:

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -5,6 +5,9 @@
  * Drupal site-specific configuration file.
  */
 
+ // Cache backend.
+define('CACHE_BACKEND', 'cache.backend.null');
+
 // Database settings, overridden per environment.
 $databases = [];
 $databases['default']['default'] = [
@@ -66,9 +69,9 @@ switch ($env) {
     $settings['container_yamls'][] = DRUPAL_ROOT . '/sites/development.services.yml';
     $config['system.performance']['css']['preprocess'] = FALSE;
     $config['system.performance']['js']['preprocess'] = FALSE;
-    $settings['cache']['bins']['render'] = 'cache.backend.null';
-    $settings['cache']['bins']['dynamic_page_cache'] = 'cache.backend.null';
-    $settings['cache']['bins']['page'] = 'cache.backend.null';
+    $settings['cache']['bins']['render'] = CACHE_BACKEND;
+    $settings['cache']['bins']['dynamic_page_cache'] = CACHE_BACKEND;
+    $settings['cache']['bins']['page'] = CACHE_BACKEND;
     $settings['extension_discovery_scan_tests'] = FALSE;
     break;
 

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -5,7 +5,7 @@
  * Drupal site-specific configuration file.
  */
 
- // Cache backend.
+// Cache backend.
 define('CACHE_BACKEND', 'cache.backend.null');
 
 // Database settings, overridden per environment.


### PR DESCRIPTION
## Changes

- Defines a constant instead of duplicating literals, resolves #349,
- Deactivates and documents the fixed database port.