### PR TITLE
Add Lando Adminer service, fixes #359.

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -133,6 +133,16 @@ services:
   #     environment:
   #       ADMIN_PORT: ":6082"
   #       VARNISH_ALLOW_UNRESTRICTED_PURGE: "true"
+  # adminer:
+  #   type: compose
+  #   meUser: adminer
+  #   services:
+  #     image: adminer:latest
+  #     depends_on:
+  #       - database
+  #     command: "php -S [::]:8080 -t /var/www/html"
+  #     volumes:
+  #       - ./.lando/adminer.php:/var/www/html/index.php
 
 proxy:
   mailhog:
@@ -143,6 +153,8 @@ proxy:
   #   - kibana.lndo.site:5601
   # varnish:
   #   - varnish.drupal-project.lndo.site
+  # adminer:
+  #   - adminer.drupal-project.lndo.site:8080
 
 events:
   post-db-import:
@@ -152,4 +164,4 @@ env_file:
   - .lando/.env
 
 # Tested with Lando version
-version: v3.11.0
+version: v3.18.0

--- a/.lando/adminer.php
+++ b/.lando/adminer.php
@@ -1,0 +1,25 @@
+<?php
+function adminer_object()
+{
+
+  class AdminerSoftware extends Adminer
+  {
+
+    public function credentials()
+    {
+      // server, username and password for connecting to database
+      return array('database', 'drupal10', 'drupal10');
+    }
+
+    public function login($login, $password)
+    {
+      // don't validate credentials submitted via form
+      return true;
+    }
+
+  }
+
+  return new AdminerSoftware;
+}
+
+include_once './adminer.php';

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Drush alias for **current** Silta feature branch deployment is `drush @current s
 ## Local environment
 
 - Appserver: <https://drupal-project.lndo.site>
+- Adminer: <http://adminer.drupal-project.lndo.site>
 - Elasticsearch: <http://localhost:9200>, <http://elasticsearch.lndo.site>
 - Kibana: <http://localhost:5601>, <http://kibana.lndo.site>
 - Mailhog: <http://mail.lndo.site>
@@ -41,6 +42,7 @@ Drush alias for **current** Silta feature branch deployment is `drush @current s
 
 ### [Services](https://docs.lando.dev/core/v3/services.html)
 
+- `adminer` - uses [Adminer database management tool](https://www.adminer.org/) image, uncomment the service definition at `.lando.yml` to enable.
 - `chrome` - uses [selenium/standalone-chrome](https://hub.docker.com/r/selenium/standalone-chrome/) image, uncomment the service definition at `.lando.yml` to enable.
 - `elasticsearch` - uses official [Elasticsearch image](https://hub.docker.com/r/elastic/elasticsearch), uncomment the service definition at `.lando.yml` to enable. Requires [at least 4GiB of memory](https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html).
 - `kibana`  - uses official [Kibana image](https://hub.docker.com/r/elastic/kibana), uncomment the service definition at `.lando.yml` to enable.


### PR DESCRIPTION
*Link to ticket: #359*

*Changes proposed in this PR:*
- Add the [Adminer](https://www.adminer.org/) Lando service based on the official [Adminer Docker image](https://hub.docker.com/_/adminer). We have several projects where Adminer is added via https://github.com/dehy/docker-adminer and the current implementation unfortunately causes extra build time because of hackish setup. Let's start using the official image instead with proper implementation. 

*How to test:*
1. Uncomment Adminer service & proxy address at `.lando.yml` and rebuild Lando via `lando rebuild -y`.
2. Validate that http://adminer.drupal-project.lndo.site address is green and you can use it (no credentials needed).

*Link to feature environment:*
- http://adminer.drupal-project.lndo.site
