### PR TITLE
Define Drupal public files path.

### DIFF
--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -24,6 +24,9 @@ $databases['default']['default'] = [
 // Salt for one-time login links, cancel links, form tokens, etc.
 $settings['hash_salt'] = $_ENV['HASH_SALT'];
 
+// Public files path.
+$settings['file_public_path']  = 'sites/default/files';
+
 // Location of the site configuration files.
 $settings['config_sync_directory'] = '../config/sync';
 


### PR DESCRIPTION
## Link to feature environment:

https://feature-public-files.drupal-project.dev.wdr.io

## Changes proposed in this PR:

This change specifically sets the path to Drupal's public files as per https://www.drupal.org/upgrade/file_public_path.

Note that private files path is defined in `settings.silta.php` as follows:
 
```php
/**
 * If a volume has been set for private files, tell Drupal about it.
 */
if (getenv('PRIVATE_FILES_PATH')) {
  $settings['file_private_path'] = getenv('PRIVATE_FILES_PATH');
}
```


