### PR TITLE
Set the PHP container default user to www-data, fixes #377.

### DIFF
--- a/silta/php.Dockerfile
+++ b/silta/php.Dockerfile
@@ -2,3 +2,5 @@
 FROM wunderio/silta-php-fpm:8.1-fpm-v1
 
 COPY --chown=www-data:www-data . /app
+
+USER www-data


### PR DESCRIPTION
## Link to ticket: 

#377 

## Changes proposed in this PR:

Set the PHP container default user to `www-data`

## How to test

SSH to feature environment and perform `whoami`.