### PR TITLE
SLT-898: Redefine default cron schedules for different envs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,8 @@ workflows:
           context: analyze
           sources: web
 
+      # Build and deploy job for feature environments.
+      # Other jobs defined below extend this job.
       - silta/drupal-build-deploy: &build-deploy
           name: build-deploy
           executor: cicd81
@@ -33,10 +35,23 @@ workflows:
             branches:
               ignore:
                 - production
+                - main
                 - /dependabot\/.*/
 
+      # Build and deploy job for main environment.
+      # Extends the job defined for feature environments.
       - silta/drupal-build-deploy:
-          # Extend the build-deploy configuration for the production environment.
+          <<: *build-deploy
+          name: build-deploy-main
+          silta_config: silta/silta.yml,silta/silta-main.yml
+          filters:
+            branches:
+              only:
+                - main
+
+      # Build and deploy job for production environment.
+      # Extends the job defined for feature environments.
+      - silta/drupal-build-deploy:
           <<: *build-deploy
           name: build-deploy-prod
           silta_config: silta/silta.yml,silta/silta-prod.yml

--- a/silta/silta-main.yml
+++ b/silta/silta-main.yml
@@ -4,5 +4,4 @@ php:
   cron:
     drupal:
       # In main environment, run cron once an hour. Adjust as needed.
-      # ~ gets replaced with a random digit between 0 and 9 to prevent having all cron jobs at once.
       schedule: '~ * * * *'

--- a/silta/silta-main.yml
+++ b/silta/silta-main.yml
@@ -1,0 +1,8 @@
+# Overrides used for main branch.
+
+php:
+  cron:
+    drupal:
+      # In main environment, run cron once an hour. Adjust as needed.
+      # ~ gets replaced with a random digit between 0 and 9 to prevent having all cron jobs at once.
+      schedule: '~ * * * *'

--- a/silta/silta-prod.yml
+++ b/silta/silta-prod.yml
@@ -14,7 +14,11 @@ backup:
   enabled: true
 
 php:
-  # Reserve more resources for our PHP containerss.
+  cron:
+    drupal:
+      # In production environments, run cron every 5 minutes. Adjust as needed.
+      schedule: '*/5 * * * *'
+  # Reserve more resources for our PHP containers.
   resources:
     requests:
       cpu: 200m

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -8,9 +8,10 @@ php:
   drupalCoreVersion: "10"
   cron:
     drupal:
-      # In feature environments, run cron jobs very seldom. Adjust as needed.
-      # ~ gets replaced with a random digit between 0 and 9 to prevent having all cron jobs at once.
-      schedule: '~ 0 1 2 *'
+      # Disable cron jobs in feature environments by using non-existing date.
+      # The ~ symbol will be replaced by a random digit from 0 to 9.
+      # This will avoid running all cron jobs at the same time.
+      schedule: '~ 0 31 2 *'
 
 # Configure reference data that will be used when creating new environments.
 referenceData:

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -6,6 +6,11 @@
 
 php:
   drupalCoreVersion: "10"
+  cron:
+    drupal:
+      # In feature environments, run cron jobs very seldom. Adjust as needed.
+      # ~ gets replaced with a random digit between 0 and 9 to prevent having all cron jobs at once.
+      schedule: '~ 0 1 2 *'
 
 # Configure reference data that will be used when creating new environments.
 referenceData:


### PR DESCRIPTION
Proposed changes:
- Adds a new silta-main.yml, which will be used in main env
- Defines new default cron schedules separately for feature envs, main env and production env. The point here is to have cron jobs run very seldomly in feature envs unless specifically needed to run more frequently.

This PR is based on https://github.com/wunderio/drupal-project-k8s/pull/675