### PR TITLE
WD-241: Add a custom decryption key to main branch deployment.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,9 @@ workflows:
                 secret_key_env: SEC_DRUPAL_PROJECT_SILTA_DEV
           silta_config: silta/silta.yml,silta/silta.secret
           context: silta_dev
+          requires:
+            - validate
+            - analyze
           filters:
             branches:
               ignore:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,12 +52,6 @@ workflows:
       - silta/drupal-build-deploy:
           <<: *build-deploy
           name: build-deploy-main
-          codebase-build:
-            - silta/drupal-composer-install
-            - silta/npm-install-build
-            - silta/decrypt-files:
-                files: silta/silta.secret
-                secret_key_env: SEC_DRUPAL_PROJECT_SILTA_DEV
           silta_config: silta/silta.yml,silta/silta.secret,silta/silta-main.yml
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,7 +49,13 @@ workflows:
       - silta/drupal-build-deploy:
           <<: *build-deploy
           name: build-deploy-main
-          silta_config: silta/silta.yml,silta/silta-main.yml
+          codebase-build:
+            - silta/drupal-composer-install
+            - silta/npm-install-build
+            - silta/decrypt-files:
+                files: silta/silta.secret
+                secret_key_env: SEC_DRUPAL_PROJECT_SILTA_DEV
+          silta_config: silta/silta.yml,silta/silta.secret,silta/silta-main.yml
           filters:
             branches:
               only:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Drush alias for the **current** Silta feature branch deployment is `drush @curre
 
 The following secret variables are defined in the file `silta/silta.secret` for the context `silta_dev`:
 
-- `TEST_KEY` - secret key for tesing purposes.
+- `TEST_KEY` - secret key for testing purposes.
 
 ## Local environment
 


### PR DESCRIPTION
### Changes

Add a custom decryption key to main branch deployment after merging https://github.com/wunderio/drupal-project/pull/379 in. https://github.com/wunderio/drupal-project/pull/383 follow-up.

### Testing

Both feature & main environments should have `TEST_KEY` envvar available:

```sh
main-shell-65bf7c9597-fl5bs:/var/www/html$ env | grep TEST_KEY
```