### PR TITLE
VSCode true is set to "explicit" since VSCode 1.85.0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true,
-    "source.fixAll.stylelint": true
+    "source.fixAll.eslint": "explicit",
+    "source.fixAll.stylelint": "explicit"
   }
 }


### PR DESCRIPTION
### Issue

[VSCode true is set to "explicit" since VSCode 1.85.0](https://github.com/wunderio/drupal-project/issues/386)

### Changes

* Change true values to `explicit`