### PR TITLE
SLT-913: Split drupal-build-deploy into two separate jobs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,11 +30,6 @@ workflows:
           codebase-build:
             - silta/drupal-composer-install
             - silta/npm-install-build
-            - silta/decrypt-files:
-                files: silta/silta.secret
-                # SEC_DRUPAL_PROJECT_SILTA_DEV holds the secret key for decryption purposes.
-                # This is stored in CircleCI as an environment variable and also in LastPass.
-                secret_key_env: SEC_DRUPAL_PROJECT_SILTA_DEV
           context: silta_dev
           requires:
             - validate
@@ -52,6 +47,12 @@ workflows:
           name: deploy
           executor: cicd81
           silta_config: silta/silta.yml,silta/silta.secret
+          pre-release:
+            - silta/decrypt-files:
+                files: silta/silta.secret
+                # SEC_DRUPAL_PROJECT_SILTA_DEV holds the secret key for decryption purposes.
+                # This is stored in CircleCI as an environment variable and also in LastPass.
+                secret_key_env: SEC_DRUPAL_PROJECT_SILTA_DEV
           context: silta_dev
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,10 +22,10 @@ workflows:
           context: analyze
           sources: web
 
-      # Build and deploy job for feature environments.
+      # Build job for feature environments.
       # Other jobs defined below extend this job.
-      - silta/drupal-build-deploy: &build-deploy
-          name: build-deploy
+      - silta/drupal-build: &build
+          name: build
           executor: cicd81
           codebase-build:
             - silta/drupal-composer-install
@@ -35,7 +35,6 @@ workflows:
                 # SEC_DRUPAL_PROJECT_SILTA_DEV holds the secret key for decryption purposes.
                 # This is stored in CircleCI as an environment variable and also in LastPass.
                 secret_key_env: SEC_DRUPAL_PROJECT_SILTA_DEV
-          silta_config: silta/silta.yml,silta/silta.secret
           context: silta_dev
           requires:
             - validate
@@ -47,22 +46,57 @@ workflows:
                 - main
                 - /dependabot\/.*/
 
-      # Build and deploy job for main environment.
+      # Deploy job for feature environments.
+      # Other jobs defined below extend this job.
+      - silta/drupal-deploy: &deploy
+          name: deploy
+          executor: cicd81
+          silta_config: silta/silta.yml,silta/silta.secret
+          context: silta_dev
+          requires:
+            - build
+          filters:
+            branches:
+              ignore:
+                - production
+                - main
+                - /dependabot\/.*/
+
+      # Build job for main environment.
       # Extends the job defined for feature environments.
-      - silta/drupal-build-deploy:
-          <<: *build-deploy
-          name: build-deploy-main
+      - silta/drupal-build:
+          <<: *build
+          filters:
+            branches:
+              only:
+                - main
+
+      # Deploy job for main environment.
+      # Extends the job defined for feature environments.
+      - silta/drupal-deploy:
+          <<: *deploy
+          name: deploy-main
           silta_config: silta/silta.yml,silta/silta.secret,silta/silta-main.yml
           filters:
             branches:
               only:
                 - main
 
-      # Build and deploy job for production environment.
+      # Build job for production environment.
       # Extends the job defined for feature environments.
-      - silta/drupal-build-deploy:
-          <<: *build-deploy
-          name: build-deploy-prod
+      - silta/drupal-build:
+          <<: *build
+          name: build
+          context: silta_finland
+          filters:
+            branches:
+              only: production
+
+      # Deploy job for production environment.
+      # Extends the job defined for feature environments.
+      - silta/drupal-deploy:
+          <<: *deploy
+          name: deploy-prod
           silta_config: silta/silta.yml,silta/silta-prod.yml
           context: silta_finland
           filters:
@@ -70,10 +104,10 @@ workflows:
               only: production
 
       # This enables validation on dependabot PRs
-      #- silta/drupal-build-deploy:
-      #    <<: *build-deploy
-      #    name: build-dependabot
-      #    context: silta_dev
+      # Build job for dependabot environments.
+      # Extends the job defined for feature environments.
+      #- silta/drupal-build:
+      #    <<: *build
       #    skip-deployment: true
       #    filters:
       #      branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,7 @@ workflows:
       # Extends the job defined for feature environments.
       - silta/drupal-build:
           <<: *build
+          name: build-main
           filters:
             branches:
               only:
@@ -77,6 +78,8 @@ workflows:
           <<: *deploy
           name: deploy-main
           silta_config: silta/silta.yml,silta/silta.secret,silta/silta-main.yml
+          requires:
+            - build-main
           filters:
             branches:
               only:
@@ -86,7 +89,7 @@ workflows:
       # Extends the job defined for feature environments.
       - silta/drupal-build:
           <<: *build
-          name: build
+          name: build-prod
           context: silta_finland
           filters:
             branches:
@@ -99,6 +102,8 @@ workflows:
           name: deploy-prod
           silta_config: silta/silta.yml,silta/silta-prod.yml
           context: silta_finland
+          requires:
+            - build-prod
           filters:
             branches:
               only: production
@@ -108,6 +113,7 @@ workflows:
       # Extends the job defined for feature environments.
       #- silta/drupal-build:
       #    <<: *build
+      #    name: build-dependabot
       #    skip-deployment: true
       #    filters:
       #      branches:


### PR DESCRIPTION
# Link to ticket: 

https://wunder.atlassian.net/browse/SLT-913

# Changes proposed in this PR:

Implement the two new jobs introduced in https://github.com/wunderio/silta-circleci/pull/187

Detailed reasoning can be found in the ticket, but for those without access to it, the gist is: Due to how CircleCi machine types and resource classes work, this change will use less CircleCi credits even though it might slightly increase the total deployment time.

We have already implemented this in drupal-project-k8s at https://github.com/wunderio/drupal-project-k8s/pull/678

<img width="1036" alt="slt-913-split-jobs-1" src="https://github.com/wunderio/drupal-project/assets/922901/80ce27e4-c501-44b3-a6fb-91517db21078">

# How to test

## Testing in feature environment:

Browse through the [circleci jobs](https://app.circleci.com/pipelines/github/wunderio/drupal-project/890/workflows/efc38f39-1342-4d4d-b64c-a62114d6918f) and check that everything looks okay compared to the [jobs in main](https://app.circleci.com/pipelines/github/wunderio/drupal-project/882/workflows/e3dcec0b-5c22-4779-82bd-3b1a9f0c38f8) branch.

## Local testing

This PR affects only CircleCi, not local environments.
