### PR TITLE
SLT-962: Require manual approval before deploying feature environments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,11 +30,6 @@ workflows:
           codebase-build:
             - silta/drupal-composer-install
             - silta/npm-install-build
-            - silta/decrypt-files:
-                files: silta/silta.secret
-                # SEC_DRUPAL_PROJECT_SILTA_DEV holds the secret key for decryption purposes.
-                # This is stored in CircleCI as an environment variable and also in LastPass.
-                secret_key_env: SEC_DRUPAL_PROJECT_SILTA_DEV
           context: silta_dev
           requires:
             - validate
@@ -52,6 +47,12 @@ workflows:
           name: deploy
           executor: cicd81
           silta_config: silta/silta.yml,silta/silta.secret
+          pre-release:
+            - silta/decrypt-files:
+                files: silta/silta.secret
+                # SEC_DRUPAL_PROJECT_SILTA_DEV holds the secret key for decryption purposes.
+                # This is stored in CircleCI as an environment variable and also in LastPass.
+                secret_key_env: SEC_DRUPAL_PROJECT_SILTA_DEV
           context: silta_dev
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,10 +22,10 @@ workflows:
           context: analyze
           sources: web
 
-      # Build and deploy job for feature environments.
+      # Build job for feature environments.
       # Other jobs defined below extend this job.
-      - silta/drupal-build-deploy: &build-deploy
-          name: build-deploy
+      - silta/drupal-build: &build
+          name: build
           executor: cicd81
           codebase-build:
             - silta/drupal-composer-install
@@ -35,7 +35,6 @@ workflows:
                 # SEC_DRUPAL_PROJECT_SILTA_DEV holds the secret key for decryption purposes.
                 # This is stored in CircleCI as an environment variable and also in LastPass.
                 secret_key_env: SEC_DRUPAL_PROJECT_SILTA_DEV
-          silta_config: silta/silta.yml,silta/silta.secret
           context: silta_dev
           requires:
             - validate
@@ -47,22 +46,57 @@ workflows:
                 - main
                 - /dependabot\/.*/
 
-      # Build and deploy job for main environment.
+      # Deploy job for feature environments.
+      # Other jobs defined below extend this job.
+      - silta/drupal-deploy: &deploy
+          name: deploy
+          executor: cicd81
+          silta_config: silta/silta.yml,silta/silta.secret
+          context: silta_dev
+          requires:
+            - build
+          filters:
+            branches:
+              ignore:
+                - production
+                - main
+                - /dependabot\/.*/
+
+      # Build job for main environment.
       # Extends the job defined for feature environments.
-      - silta/drupal-build-deploy:
-          <<: *build-deploy
-          name: build-deploy-main
+      - silta/drupal-build:
+          <<: *build
+          filters:
+            branches:
+              only:
+                - main
+
+      # Deploy job for main environment.
+      # Extends the job defined for feature environments.
+      - silta/drupal-deploy:
+          <<: *deploy
+          name: deploy-main
           silta_config: silta/silta.yml,silta/silta.secret,silta/silta-main.yml
           filters:
             branches:
               only:
                 - main
 
-      # Build and deploy job for production environment.
+      # Build job for production environment.
       # Extends the job defined for feature environments.
-      - silta/drupal-build-deploy:
-          <<: *build-deploy
-          name: build-deploy-prod
+      - silta/drupal-build:
+          <<: *build
+          name: build
+          context: silta_finland
+          filters:
+            branches:
+              only: production
+
+      # Deploy job for production environment.
+      # Extends the job defined for feature environments.
+      - silta/drupal-deploy:
+          <<: *deploy
+          name: deploy-prod
           silta_config: silta/silta.yml,silta/silta-prod.yml
           context: silta_finland
           filters:
@@ -70,10 +104,10 @@ workflows:
               only: production
 
       # This enables validation on dependabot PRs
-      #- silta/drupal-build-deploy:
-      #    <<: *build-deploy
-      #    name: build-dependabot
-      #    context: silta_dev
+      # Build job for dependabot environments.
+      # Extends the job defined for feature environments.
+      #- silta/drupal-build:
+      #    <<: *build
       #    skip-deployment: true
       #    filters:
       #      branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,16 @@ executors:
 workflows:
   commit:
     jobs:
+      - approval:
+          type: approval
+          name: approve-deployment
+          filters:
+            branches:
+              ignore:
+                - production
+                - main
+                - /dependabot\/.*/
+
       - silta/drupal-validate:
           name: validate
           executor: cicd81
@@ -34,6 +44,7 @@ workflows:
           requires:
             - validate
             - analyze
+            - approve-deployment
           filters:
             branches:
               ignore:
@@ -68,6 +79,9 @@ workflows:
       - silta/drupal-build:
           <<: *build
           name: build-main
+          requires:
+            - validate
+            - analyze
           filters:
             branches:
               only:
@@ -92,6 +106,9 @@ workflows:
           <<: *build
           name: build-prod
           context: silta_finland
+          requires:
+            - validate
+            - analyze
           filters:
             branches:
               only: production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,7 @@ workflows:
       # Extends the job defined for feature environments.
       - silta/drupal-build:
           <<: *build
+          name: build-main
           filters:
             branches:
               only:
@@ -77,6 +78,8 @@ workflows:
           <<: *deploy
           name: deploy-main
           silta_config: silta/silta.yml,silta/silta.secret,silta/silta-main.yml
+          requires:
+            - build-main
           filters:
             branches:
               only:
@@ -86,7 +89,7 @@ workflows:
       # Extends the job defined for feature environments.
       - silta/drupal-build:
           <<: *build
-          name: build
+          name: build-prod
           context: silta_finland
           filters:
             branches:
@@ -99,6 +102,8 @@ workflows:
           name: deploy-prod
           silta_config: silta/silta.yml,silta/silta-prod.yml
           context: silta_finland
+          requires:
+            - build-prod
           filters:
             branches:
               only: production
@@ -108,6 +113,7 @@ workflows:
       # Extends the job defined for feature environments.
       #- silta/drupal-build:
       #    <<: *build
+      #    name: build-dependabot
       #    skip-deployment: true
       #    filters:
       #      branches:


### PR DESCRIPTION
# Link to ticket: 

https://wunder.atlassian.net/browse/SLT-962

# Changes proposed in this PR:

- **This PR is based off of #388**
- For feature branches/environments, adds an approval step in the circleci workflow, which much be manually approved before the workflow proceeds to build and deploy the environment
- This is to avoid using unnecessary Circleci and Silta resources when deploying the environment is not needed

# How to test

## Testing in feature environment:

- See the added approval step at https://app.circleci.com/pipelines/github/wunderio/drupal-project/912/workflows/7d26f72e-0bad-41fd-9aba-d845eef7ce45

