### PR TITLE
Fix drush alias when projectName doesn't exist

### DIFF
--- a/drush/Commands/SiltaAliasAlterCommands.php
+++ b/drush/Commands/SiltaAliasAlterCommands.php
@@ -106,8 +106,8 @@ class SiltaAliasAlterCommands extends DrushCommands implements SiteAliasManagerA
         $silta_config_file = 'silta/silta.yml';
         if (file_exists($silta_config_file)) {
             $silta_config = Yaml::parse(file_get_contents($silta_config_file));
-            if ($project_name = $silta_config['projectName']) {
-                return $project_name;
+            if (isset($silta_config['projectName'])) {
+                return $silta_config['projectName'];
             }
         }
         return NULL;


### PR DESCRIPTION
Currently when projectName is not set in silta.yml, there is an error:
```bash
❯ lando drush @main st
 [warning] Undefined array key "projectName" SiltaAliasAlterCommands.php:109
^C [warning] Drush command terminated abnormally.
```