### PR TITLE
SLT-918: Use latest silta-nginx image

### DIFF
--- a/silta/nginx.Dockerfile
+++ b/silta/nginx.Dockerfile
@@ -1,4 +1,4 @@
 # Dockerfile for the Nginx container.
-FROM wunderio/silta-nginx:1.17-v1
+FROM wunderio/silta-nginx:1.24-v1
 
 COPY . /app/web


### PR DESCRIPTION
# Link to ticket: 

https://wunder.atlassian.net/browse/SLT-918

# Changes proposed in this PR:

Bump silta/nginx.Dockerfile to use the latest version of wunderio/silta-nginx image.

# How to test

## Testing in feature environment:

https://feature-slt-918-nginx-version.drupal-project.dev.wdr.io

## Testing steps

_Testing scenario goes here._

1. Just test that the site still works
