### PR TITLE
SLT-919: Use php 8.2 and node 20

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,16 +4,16 @@ orbs:
   silta: silta/silta@1
 
 executors:
-  cicd81:
+  cicd82:
     docker:
-      - image: wunderio/silta-cicd:circleci-php8.1-node16-composer2-v1
+      - image: wunderio/silta-cicd:circleci-php8.2-node20-composer2-v1
 
 workflows:
   commit:
     jobs:
       - silta/drupal-validate:
           name: validate
-          executor: cicd81
+          executor: cicd82
           post-validation:
             - run: echo "You can add additional validation here!"
 
@@ -26,7 +26,7 @@ workflows:
       # Other jobs defined below extend this job.
       - silta/drupal-build: &build
           name: build
-          executor: cicd81
+          executor: cicd82
           codebase-build:
             - silta/drupal-composer-install
             - silta/npm-install-build
@@ -45,7 +45,7 @@ workflows:
       # Other jobs defined below extend this job.
       - silta/drupal-deploy: &deploy
           name: deploy
-          executor: cicd81
+          executor: cicd82
           silta_config: silta/silta.yml,silta/silta.secret
           pre-release:
             - silta/decrypt-files:

--- a/.lando.yml
+++ b/.lando.yml
@@ -2,7 +2,7 @@ name: drupal-project
 recipe: drupal10
 
 config:
-  php: "8.1"
+  php: "8.2"
   via: nginx
   webroot: web
   database: "mariadb:10.3"
@@ -122,7 +122,7 @@ services:
     hogfrom:
       - appserver
   node:
-    type: "node:16"
+    type: "node:20"
     build:
       - "npm install"
   # varnish:

--- a/silta/php.Dockerfile
+++ b/silta/php.Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for the PHP container.
-FROM wunderio/silta-php-fpm:8.1-fpm-v1
+FROM wunderio/silta-php-fpm:8.2-fpm-v1
 
 COPY --chown=www-data:www-data . /app
 

--- a/silta/shell.Dockerfile
+++ b/silta/shell.Dockerfile
@@ -1,4 +1,4 @@
 # Dockerfile for the Shell container.
-FROM wunderio/silta-php-shell:php8.1-v1
+FROM wunderio/silta-php-shell:php8.2-v1
 
 COPY --chown=www-data:www-data . /app


### PR DESCRIPTION
# Link to ticket: 

https://wunder.atlassian.net/browse/SLT-919

# Changes proposed in this PR:

Bump silta/php.Dockerfile to use the latest silta-php-fpm image, silta/shell.Dockerfile to use the latest silta-php-shell image and .circleci/config.yml to use the latest silta-cicd image. These have php version 8.2 and the cicd image has node version 20.,

Also update Lando to use php 8.2 and node20.

# How to test

## Testing in feature environment:

https://feature-slt-919-php-version.drupal-project.dev.wdr.io

## Local testing

Lando rebuild and verify the new versions are used. Verify local development works as usual.

## Testing steps

1. Just test that the site and deployments work.

