### PR TITLE
WD-253: Introduce JIRA ticket number validation in commit messages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,11 @@ To use these commands, you need a secret key that is used to encrypt and decrypt
 You should use the following naming convention for your custom keys: `SEC_{PROJECT_NAME}_{CONTEXT}` where `CONTEXT` refers to the environment you are working on, such as `silta_dev` (development context) or `silta_finland` (production context). For example, if you are working on the `drupal-project` project in the `silta_dev` environment, you should use the `SEC_DRUPAL_PROJECT_SILTA_DEV` key.
 
 The `silta/silta.secret` file is a YAML file that contains the encrypted secrets for your project in the default `silta-dev` context. You can add more files for other contexts, such as `silta/silta-prod.secret` for the production context.
+
+## Contributing
+
+This project is maintained by [Wunder](https://wunder.io/). We welcome contributions from the community.
+
+Internally, we use JIRA for project management, but we also use GitHub issues for public projects.
+
+Introduce your idea in the issue queue and prefix the pull request and commit messages with the issue key in the following format: `GH-123: Add a new feature`. In this way, the issue is automatically linked to your contribution.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ This project template is an opinionated fork of the popular [Drupal-composer tem
   - make the repository private (unless the project is public).
 - Clone the new project locally and modify its details:
   - `composer.json` name,
-  - `silta/silta.yml` [values](https://github.com/wunderio/charts/blob/master/drupal/values.yaml).
+  - `silta/silta.yml` [values](https://github.com/wunderio/charts/blob/master/drupal/values.yaml),
+  - `grumphp.yml` tasks, including the project name in `git_commit_message` regex.
 - Log in to [CircleCI](https://app.circleci.com/) using your Github account and add the new project using existing config.
 
 For additional instructions, please see the [Silta documentation](https://github.com/wunderio/silta).

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This project template is an opinionated fork of the popular [Drupal-composer tem
   - `silta/silta.yml` [values](https://github.com/wunderio/charts/blob/master/drupal/values.yaml),
   - `grumphp.yml` tasks, including the project name in `git_commit_message` regex.
 - Log in to [CircleCI](https://app.circleci.com/) using your Github account and add the new project using existing config.
+- Configure [automatic autolinks](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls#custom-autolinks-to-external-resources) for the project's JIRA environment.
 
 For additional instructions, please see the [Silta documentation](https://github.com/wunderio/silta).
 

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -11,9 +11,9 @@ grumphp:
       max_body_width: 0
       max_subject_width: 0
       matchers:
-        # Change the universal template regex to match your project name.
-        # Example for a JIRA project called WD: '/^WD-[0-9]+: /'.
-        'The commit must start with the JIRA issue number': '/^[A-Z]+-[0-9]+: /'
+        # Modify the universal JIRA regex provided to suit your project requirements, incl. name.
+        # For example, the regex for a project called WD would be: `/^WD-[1-9][0-9]*: /`.
+        'The commit must start with the JIRA issue number': '/^[A-Z][A-Z0-9_]+-[1-9][0-9]*: /'
     php_compatibility:
       run_on: '%grumphp.run_on_paths%'
       testVersion: '8.1'

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -7,6 +7,13 @@ grumphp:
     failed: ~
     succeeded: ~
   tasks:
+    git_commit_message:
+      max_body_width: 0
+      max_subject_width: 0
+      matchers:
+        # Change the universal template regex to match your project name.
+        # Example for a JIRA project called WD: '/^WD-[0-9]+: /'.
+        'The commit must start with the JIRA issue number': '/^[A-Z]+-[0-9]+: /'
     php_compatibility:
       run_on: '%grumphp.run_on_paths%'
       testVersion: '8.1'

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -13,7 +13,7 @@ grumphp:
       matchers:
         # Modify the universal JIRA regex provided to suit your project requirements, incl. name.
         # For example, the regex for a project called WD would be: `/^WD-[1-9][0-9]*: /`.
-        'The commit must start with the JIRA issue number': '/^[A-Z][A-Z0-9_]+-[1-9][0-9]*: /'
+        'The commit must start with the JIRA or GitHub issue number': '/^[A-Z][A-Z0-9_]+-[1-9][0-9]*: /'
     php_compatibility:
       run_on: '%grumphp.run_on_paths%'
       testVersion: '8.1'


### PR DESCRIPTION
Ticket: WD-253

## Changes

This PR introduces JIRA ticket number validation in GIT commit messages via GrumPHP [git_commit_message](https://github.com/phpro/grumphp/blob/v2.x/doc/tasks/git_commit_message.md) task.

General [JIRA ticket code regex](https://stackoverflow.com/a/73914895) is implemented as a default rule: `/^[A-Z][A-Z0-9_]+-[1-9][0-9]*: /`.

When implementing in a specific project, the name of the JIRA project should be specified. For example, the regex for a project called WD would be: `/^WD-[1-9][0-9]*: /`.

## Testing

- Try making commits without a JIRA ticket reference, it should fail.
- Try making commits with JIRA ticket name at the beginning of commit message, f. ex: `LA004311-3325: `. It should pass.