### PR TITLE
SLT-919: Update GrumPHP & Composer setups to PHP v8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": ">=8.1",
+        "php": ">=8.2",
         "composer/installers": "^2.1",
         "cweagans/composer-patches": "^1.7",
         "drupal/admin_toolbar": "^3.3",
@@ -25,7 +25,7 @@
         "drupal/purge": "^3.4",
         "drupal/simplei": "^2.0@beta",
         "drupal/varnish_purge": "^2.2",
-        "drush/drush": "^11.4",
+        "drush/drush": "^11.6",
         "vlucas/phpdotenv": "^5.4",
         "webflo/drupal-finder": "^1.2",
         "wunderio/drupal-ping": "^2.4"

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -16,7 +16,7 @@ grumphp:
         'The commit must start with the JIRA or GitHub issue number': '/^[A-Z][A-Z0-9_]+-[1-9][0-9]*: /'
     php_compatibility:
       run_on: '%grumphp.run_on_paths%'
-      testVersion: '8.1'
+      testVersion: '8.2'
     check_file_permissions: ~
     php_check_syntax:
       run_on: '%grumphp.run_on_paths%'


### PR DESCRIPTION
Ticket: SLT-919

## Changes

- SLT-919: Update GrumPHP & Composer setups to PHP v8.2
- Update Drush to the latest.