### PR TITLE
WD-254: Upgrade Drupal core to 10.2.5, update other Composer packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,23 +16,23 @@
     ],
     "require": {
         "php": ">=8.2",
-        "composer/installers": "^2.1",
+        "composer/installers": "^2.2",
         "cweagans/composer-patches": "^1.7",
-        "drupal/admin_toolbar": "^3.3",
-        "drupal/core-composer-scaffold": "^10.0",
-        "drupal/core-recommended": "^10.0",
-        "drupal/monolog": "^3.0@beta",
-        "drupal/purge": "^3.4",
-        "drupal/simplei": "^2.0@beta",
+        "drupal/admin_toolbar": "^3.4",
+        "drupal/core-composer-scaffold": "^10.2",
+        "drupal/core-recommended": "^10.2",
+        "drupal/monolog": "^3.0",
+        "drupal/purge": "^3.5",
+        "drupal/simplei": "^2.1",
         "drupal/varnish_purge": "^2.2",
-        "drush/drush": "^11.6",
-        "vlucas/phpdotenv": "^5.4",
+        "drush/drush": "^12.5",
+        "vlucas/phpdotenv": "^5.6",
         "webflo/drupal-finder": "^1.2",
-        "wunderio/drupal-ping": "^2.4"
+        "wunderio/drupal-ping": "^2.5"
     },
     "require-dev": {
-        "drupal/core-dev": "^10.0",
-        "wunderio/code-quality": "^2.2"
+        "drupal/core-dev": "^10.2",
+        "wunderio/code-quality": "^2.4"
     },
     "conflict": {
         "drupal/drupal": "*"
@@ -47,7 +47,8 @@
             "drupal/core-composer-scaffold": true,
             "koodimonni/composer-dropin-installer": true,
             "phpro/grumphp": true,
-            "phpstan/extension-installer": true
+            "phpstan/extension-installer": true,
+            "php-http/discovery": true
         },
         "discard-changes": true,
         "process-timeout": 0,

--- a/web/profiles/custom/basic/config/install/core.entity_form_mode.user.register.yml
+++ b/web/profiles/custom/basic/config/install/core.entity_form_mode.user.register.yml
@@ -5,5 +5,6 @@ dependencies:
     - user
 id: user.register
 label: Register
+description: ''
 targetEntityType: user
 cache: true

--- a/web/profiles/custom/basic/config/install/core.entity_view_mode.block_content.full.yml
+++ b/web/profiles/custom/basic/config/install/core.entity_view_mode.block_content.full.yml
@@ -5,5 +5,6 @@ dependencies:
     - block_content
 id: block_content.full
 label: Full
+description: ''
 targetEntityType: block_content
 cache: true

--- a/web/profiles/custom/basic/config/install/core.entity_view_mode.comment.full.yml
+++ b/web/profiles/custom/basic/config/install/core.entity_view_mode.comment.full.yml
@@ -5,5 +5,6 @@ dependencies:
     - comment
 id: comment.full
 label: 'Full comment'
+description: ''
 targetEntityType: comment
 cache: true

--- a/web/profiles/custom/basic/config/install/core.entity_view_mode.node.full.yml
+++ b/web/profiles/custom/basic/config/install/core.entity_view_mode.node.full.yml
@@ -5,5 +5,6 @@ dependencies:
     - node
 id: node.full
 label: 'Full content'
+description: ''
 targetEntityType: node
 cache: true

--- a/web/profiles/custom/basic/config/install/core.entity_view_mode.node.rss.yml
+++ b/web/profiles/custom/basic/config/install/core.entity_view_mode.node.rss.yml
@@ -5,5 +5,6 @@ dependencies:
     - node
 id: node.rss
 label: RSS
+description: ''
 targetEntityType: node
 cache: true

--- a/web/profiles/custom/basic/config/install/core.entity_view_mode.node.search_index.yml
+++ b/web/profiles/custom/basic/config/install/core.entity_view_mode.node.search_index.yml
@@ -5,5 +5,6 @@ dependencies:
     - node
 id: node.search_index
 label: 'Search index'
+description: ''
 targetEntityType: node
 cache: true

--- a/web/profiles/custom/basic/config/install/core.entity_view_mode.node.search_result.yml
+++ b/web/profiles/custom/basic/config/install/core.entity_view_mode.node.search_result.yml
@@ -5,5 +5,6 @@ dependencies:
     - node
 id: node.search_result
 label: 'Search result highlighting input'
+description: ''
 targetEntityType: node
 cache: true

--- a/web/profiles/custom/basic/config/install/core.entity_view_mode.node.teaser.yml
+++ b/web/profiles/custom/basic/config/install/core.entity_view_mode.node.teaser.yml
@@ -5,5 +5,6 @@ dependencies:
     - node
 id: node.teaser
 label: Teaser
+description: ''
 targetEntityType: node
 cache: true

--- a/web/profiles/custom/basic/config/install/core.entity_view_mode.taxonomy_term.full.yml
+++ b/web/profiles/custom/basic/config/install/core.entity_view_mode.taxonomy_term.full.yml
@@ -5,5 +5,6 @@ dependencies:
     - taxonomy
 id: taxonomy_term.full
 label: 'Taxonomy term page'
+description: ''
 targetEntityType: taxonomy_term
 cache: true

--- a/web/profiles/custom/basic/config/install/core.entity_view_mode.user.compact.yml
+++ b/web/profiles/custom/basic/config/install/core.entity_view_mode.user.compact.yml
@@ -5,5 +5,6 @@ dependencies:
     - user
 id: user.compact
 label: Compact
+description: ''
 targetEntityType: user
 cache: true

--- a/web/profiles/custom/basic/config/install/core.entity_view_mode.user.full.yml
+++ b/web/profiles/custom/basic/config/install/core.entity_view_mode.user.full.yml
@@ -5,5 +5,6 @@ dependencies:
     - user
 id: user.full
 label: 'User account'
+description: ''
 targetEntityType: user
 cache: true

--- a/web/profiles/custom/basic/config/install/editor.editor.basic_html.yml
+++ b/web/profiles/custom/basic/config/install/editor.editor.basic_html.yml
@@ -36,8 +36,10 @@ settings:
     ckeditor5_imageResize:
       allow_resize: true
     ckeditor5_list:
-      reversed: false
-      startIndex: true
+      properties:
+        reversed: false
+        startIndex: true
+      multiBlock: true
     ckeditor5_sourceEditing:
       allowed_tags:
         - '<cite>'
@@ -47,7 +49,7 @@ settings:
         - '<a hreflang>'
         - '<blockquote cite>'
         - '<ul type>'
-        - '<ol start type>'
+        - '<ol type>'
         - '<h2 id>'
         - '<h3 id>'
         - '<h4 id>'

--- a/web/profiles/custom/basic/config/install/editor.editor.full_html.yml
+++ b/web/profiles/custom/basic/config/install/editor.editor.full_html.yml
@@ -42,10 +42,56 @@ settings:
     ckeditor5_imageResize:
       allow_resize: true
     ckeditor5_list:
-      reversed: true
-      startIndex: true
+      properties:
+        reversed: true
+        startIndex: true
+      multiBlock: true
     ckeditor5_sourceEditing:
       allowed_tags: {  }
+    ckeditor5_codeBlock:
+      languages:
+        -
+          label: 'Plain text'
+          language: plaintext
+        -
+          label: C
+          language: c
+        -
+          label: 'C#'
+          language: cs
+        -
+          label: C++
+          language: cpp
+        -
+          label: CSS
+          language: css
+        -
+          label: Diff
+          language: diff
+        -
+          label: HTML
+          language: html
+        -
+          label: Java
+          language: java
+        -
+          label: JavaScript
+          language: javascript
+        -
+          label: PHP
+          language: php
+        -
+          label: Python
+          language: python
+        -
+          label: Ruby
+          language: ruby
+        -
+          label: TypeScript
+          language: typescript
+        -
+          label: XML
+          language: xml
 image_upload:
   status: true
   scheme: public

--- a/web/profiles/custom/basic/config/install/field.field.block_content.basic.body.yml
+++ b/web/profiles/custom/basic/config/install/field.field.block_content.basic.body.yml
@@ -19,4 +19,5 @@ default_value_callback: ''
 settings:
   display_summary: false
   required_summary: false
+  allowed_formats: {  }
 field_type: text_with_summary

--- a/web/profiles/custom/basic/config/install/field.field.comment.comment.comment_body.yml
+++ b/web/profiles/custom/basic/config/install/field.field.comment.comment.comment_body.yml
@@ -16,5 +16,6 @@ required: true
 translatable: true
 default_value: {  }
 default_value_callback: ''
-settings: {  }
+settings:
+  allowed_formats: {  }
 field_type: text_long

--- a/web/profiles/custom/basic/config/install/field.field.node.article.body.yml
+++ b/web/profiles/custom/basic/config/install/field.field.node.article.body.yml
@@ -19,4 +19,5 @@ default_value_callback: ''
 settings:
   display_summary: true
   required_summary: false
+  allowed_formats: {  }
 field_type: text_with_summary

--- a/web/profiles/custom/basic/config/install/field.field.node.page.body.yml
+++ b/web/profiles/custom/basic/config/install/field.field.node.page.body.yml
@@ -19,4 +19,5 @@ default_value_callback: ''
 settings:
   display_summary: true
   required_summary: false
+  allowed_formats: {  }
 field_type: text_with_summary

--- a/web/profiles/custom/basic/config/install/filter.format.basic_html.yml
+++ b/web/profiles/custom/basic/config/install/filter.format.basic_html.yml
@@ -7,15 +7,12 @@ name: 'Basic HTML'
 format: basic_html
 weight: 0
 filters:
-  filter_html:
-    id: filter_html
-    provider: filter
+  editor_file_reference:
+    id: editor_file_reference
+    provider: editor
     status: true
-    weight: -10
-    settings:
-      allowed_html: '<br> <p> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <cite> <dl> <dt> <dd> <a hreflang href> <blockquote cite> <ul type> <ol start type> <strong> <em> <code> <li> <img src alt data-entity-uuid data-entity-type height width data-caption data-align>'
-      filter_html_help: false
-      filter_html_nofollow: false
+    weight: 11
+    settings: {  }
   filter_align:
     id: filter_align
     provider: filter
@@ -28,15 +25,18 @@ filters:
     status: true
     weight: 8
     settings: {  }
+  filter_html:
+    id: filter_html
+    provider: filter
+    status: true
+    weight: -10
+    settings:
+      allowed_html: '<br> <p> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id> <cite> <dl> <dt> <dd> <a hreflang href> <blockquote cite> <ul type> <ol start type> <strong> <em> <code> <li> <img src alt data-entity-uuid data-entity-type height width data-caption data-align>'
+      filter_html_help: false
+      filter_html_nofollow: false
   filter_html_image_secure:
     id: filter_html_image_secure
     provider: filter
     status: true
     weight: 9
-    settings: {  }
-  editor_file_reference:
-    id: editor_file_reference
-    provider: editor
-    status: true
-    weight: 11
     settings: {  }

--- a/web/profiles/custom/basic/config/install/filter.format.full_html.yml
+++ b/web/profiles/custom/basic/config/install/filter.format.full_html.yml
@@ -7,6 +7,12 @@ name: 'Full HTML'
 format: full_html
 weight: 2
 filters:
+  editor_file_reference:
+    id: editor_file_reference
+    provider: editor
+    status: true
+    weight: 11
+    settings: {  }
   filter_align:
     id: filter_align
     provider: filter
@@ -24,10 +30,4 @@ filters:
     provider: filter
     status: true
     weight: 10
-    settings: {  }
-  editor_file_reference:
-    id: editor_file_reference
-    provider: editor
-    status: true
-    weight: 11
     settings: {  }

--- a/web/profiles/custom/basic/config/install/filter.format.plain_text.yml
+++ b/web/profiles/custom/basic/config/install/filter.format.plain_text.yml
@@ -5,6 +5,12 @@ name: 'Plain text'
 format: plain_text
 weight: 10
 filters:
+  filter_autop:
+    id: filter_autop
+    provider: filter
+    status: true
+    weight: 0
+    settings: {  }
   filter_html_escape:
     id: filter_html_escape
     provider: filter
@@ -18,9 +24,3 @@ filters:
     weight: 0
     settings:
       filter_url_length: 72
-  filter_autop:
-    id: filter_autop
-    provider: filter
-    status: true
-    weight: 0
-    settings: {  }

--- a/web/profiles/custom/basic/config/install/filter.format.restricted_html.yml
+++ b/web/profiles/custom/basic/config/install/filter.format.restricted_html.yml
@@ -5,6 +5,12 @@ name: 'Restricted HTML'
 format: restricted_html
 weight: 1
 filters:
+  filter_autop:
+    id: filter_autop
+    provider: filter
+    status: true
+    weight: 0
+    settings: {  }
   filter_html:
     id: filter_html
     provider: filter
@@ -14,12 +20,6 @@ filters:
       allowed_html: '<a href hreflang> <em> <strong> <cite> <blockquote cite> <code> <ul type> <ol start type> <li> <dl> <dt> <dd> <h2 id> <h3 id> <h4 id> <h5 id> <h6 id>'
       filter_html_help: true
       filter_html_nofollow: false
-  filter_autop:
-    id: filter_autop
-    provider: filter
-    status: true
-    weight: 0
-    settings: {  }
   filter_url:
     id: filter_url
     provider: filter

--- a/web/profiles/custom/basic/config/install/system.feature_flags.yml
+++ b/web/profiles/custom/basic/config/install/system.feature_flags.yml
@@ -1,0 +1,1 @@
+linkset_endpoint: false

--- a/web/profiles/custom/basic/config/install/views.view.archive.yml
+++ b/web/profiles/custom/basic/config/install/views.view.archive.yml
@@ -1,16 +1,15 @@
 langcode: en
-status: true
+status: false
 dependencies:
   config:
     - core.entity_view_mode.node.teaser
   module:
     - node
-    - taxonomy
     - user
-id: taxonomy_term
-label: 'Taxonomy term'
-module: taxonomy
-description: 'Content belonging to a certain taxonomy term.'
+id: archive
+label: Archive
+module: node
+description: 'All content, by month.'
 tag: default
 base_table: node_field_data
 base_field: nid
@@ -21,6 +20,7 @@ display:
     display_plugin: default
     position: 0
     display_options:
+      title: 'Monthly archive'
       fields: {  }
       pager:
         type: mini
@@ -59,26 +59,15 @@ display:
         options: {  }
       empty: {  }
       sorts:
-        sticky:
-          id: sticky
-          table: taxonomy_index
-          field: sticky
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: standard
-          order: DESC
-          expose:
-            label: ''
-            field_identifier: sticky
-          exposed: false
         created:
           id: created
-          table: taxonomy_index
+          table: node_field_data
           field: created
           relationship: none
           group_type: group
           admin_label: ''
+          entity_type: node
+          entity_field: created
           plugin_id: date
           order: DESC
           expose:
@@ -87,47 +76,39 @@ display:
           exposed: false
           granularity: second
       arguments:
-        tid:
-          id: tid
-          table: taxonomy_index
-          field: tid
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: taxonomy_index_tid
-          default_action: 'not found'
+        created_year_month:
+          id: created_year_month
+          table: node_field_data
+          field: created_year_month
+          entity_type: node
+          plugin_id: date_year_month
+          default_action: summary
           exception:
-            value: ''
-            title_enable: false
-            title: All
+            title_enable: true
           title_enable: true
-          title: '{{ arguments.tid }}'
+          title: '{{ arguments.created_year_month }}'
           default_argument_type: fixed
-          default_argument_options:
-            argument: ''
           summary_options:
-            base_path: ''
-            count: true
-            override: false
-            items_per_page: 25
+            override: true
+            items_per_page: 30
           summary:
-            sort_order: asc
-            number_of_records: 0
+            sort_order: desc
             format: default_summary
           specify_validation: true
-          validate:
-            type: 'entity:taxonomy_term'
-            fail: 'not found'
-          validate_options:
-            bundles: {  }
-            access: true
-            operation: view
-            multiple: 0
-          break_phrase: false
-          add_table: false
-          require_value: false
-          reduce_duplicates: false
       filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 0
+          expose:
+            operator: '0'
+            operator_limit_selection: false
+            operator_list: {  }
         langcode:
           id: langcode
           table: node_field_data
@@ -170,44 +151,6 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
-        status:
-          id: status
-          table: taxonomy_index
-          field: status
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: boolean
-          operator: '='
-          value: '1'
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
       style:
         type: default
         options:
@@ -228,22 +171,7 @@ display:
           replica: false
           query_tags: {  }
       relationships: {  }
-      link_display: page_1
-      link_url: ''
-      header:
-        entity_taxonomy_term:
-          id: entity_taxonomy_term
-          table: views
-          field: entity_taxonomy_term
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: entity
-          empty: true
-          target: '{{ raw_arguments.tid }}'
-          view_mode: full
-          tokenize: true
-          bypass_access: false
+      header: {  }
       footer: {  }
       display_extenders: {  }
     cache_metadata:
@@ -255,41 +183,42 @@ display:
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
-  feed_1:
-    id: feed_1
-    display_title: Feed
-    display_plugin: feed
-    position: 2
+  block_1:
+    id: block_1
+    display_title: Block
+    display_plugin: block
+    position: 1
     display_options:
-      pager:
-        type: some
-        options:
-          offset: 0
-          items_per_page: 10
-      style:
-        type: rss
-        options:
-          grouping: {  }
-          uses_fields: false
-          description: ''
-      row:
-        type: node_rss
-        options:
-          relationship: none
-          view_mode: default
+      arguments:
+        created_year_month:
+          id: created_year_month
+          table: node_field_data
+          field: created_year_month
+          entity_type: node
+          plugin_id: date_year_month
+          default_action: summary
+          exception:
+            title_enable: true
+          title_enable: true
+          title: '{{ arguments.created_year_month }}'
+          default_argument_type: fixed
+          summary_options:
+            items_per_page: 30
+          summary:
+            format: default_summary
+          specify_validation: true
       query:
         type: views_query
         options: {  }
+      defaults:
+        arguments: false
       display_extenders: {  }
-      path: taxonomy/term/%/feed
-      displays:
-        page_1: page_1
-        default: '0'
     cache_metadata:
       max-age: -1
       contexts:
         - 'languages:language_interface'
         - url
+        - url.query_args
         - 'user.node_grants:view'
         - user.permissions
       tags: {  }
@@ -297,13 +226,13 @@ display:
     id: page_1
     display_title: Page
     display_plugin: page
-    position: 1
+    position: 2
     display_options:
       query:
         type: views_query
         options: {  }
       display_extenders: {  }
-      path: taxonomy/term/%
+      path: archive
     cache_metadata:
       max-age: -1
       contexts:

--- a/web/profiles/custom/basic/config/install/views.view.comment.yml
+++ b/web/profiles/custom/basic/config/install/views.view.comment.yml
@@ -391,6 +391,15 @@ display:
             date_format: short
             custom_date_format: ''
             timezone: ''
+            tooltip:
+              date_format: ''
+              custom_date_format: ''
+            time_diff:
+              enabled: false
+              future_format: '@interval hence'
+              past_format: '@interval ago'
+              granularity: 2
+              refresh: 60
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -1269,6 +1278,15 @@ display:
             date_format: short
             custom_date_format: ''
             timezone: ''
+            tooltip:
+              date_format: ''
+              custom_date_format: ''
+            time_diff:
+              enabled: false
+              future_format: '@interval hence'
+              past_format: '@interval ago'
+              granularity: 2
+              refresh: 60
           group_column: value
           group_columns: {  }
           group_rows: true

--- a/web/profiles/custom/basic/config/install/views.view.comments_recent.yml
+++ b/web/profiles/custom/basic/config/install/views.view.comments_recent.yml
@@ -1,0 +1,267 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - comment
+    - node
+    - user
+id: comments_recent
+label: 'Recent comments'
+module: views
+description: 'Recent comments.'
+tag: default
+base_table: comment_field_data
+base_field: cid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Recent comments'
+      fields:
+        subject:
+          id: subject
+          table: comment_field_data
+          field: subject
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: comment
+          entity_field: subject
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: false
+            ellipsis: false
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          type: string
+          settings:
+            link_to_entity: true
+        changed:
+          id: changed
+          table: comment_field_data
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: comment
+          entity_field: changed
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          type: timestamp_ago
+          settings:
+            future_format: '@interval hence'
+            past_format: '@interval ago'
+            granularity: 2
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 10
+      exposed_form:
+        type: basic
+      access:
+        type: perm
+        options:
+          perm: 'access comments'
+      cache:
+        type: tag
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          label: ''
+          empty: true
+          content: 'No comments available.'
+          tokenize: false
+      sorts:
+        created:
+          id: created
+          table: comment_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: comment
+          entity_field: created
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: created
+          exposed: false
+        cid:
+          id: cid
+          table: comment_field_data
+          field: cid
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: comment
+          entity_field: cid
+          plugin_id: field
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: cid
+          exposed: false
+      filters:
+        status:
+          id: status
+          table: comment_field_data
+          field: status
+          entity_type: comment
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        status_node:
+          id: status_node
+          table: node_field_data
+          field: status
+          relationship: node
+          entity_type: node
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+      style:
+        type: html_list
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          type: ul
+          wrapper_class: item-list
+          class: ''
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          hide_empty: false
+      query:
+        type: views_query
+      relationships:
+        node:
+          id: node
+          table: comment_field_data
+          field: node
+          plugin_id: standard
+          required: true
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user.permissions
+      tags: {  }
+  block_1:
+    id: block_1
+    display_title: Block
+    display_plugin: block
+    position: 1
+    display_options:
+      display_extenders: {  }
+      block_description: 'Recent comments'
+      block_category: 'Lists (Views)'
+      allow:
+        items_per_page: true
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user.permissions
+      tags: {  }

--- a/web/profiles/custom/basic/config/install/views.view.content.yml
+++ b/web/profiles/custom/basic/config/install/views.view.content.yml
@@ -184,6 +184,15 @@ display:
             date_format: short
             custom_date_format: ''
             timezone: ''
+            tooltip:
+              date_format: ''
+              custom_date_format: ''
+            time_diff:
+              enabled: false
+              future_format: '@interval hence'
+              past_format: '@interval ago'
+              granularity: 2
+              refresh: 60
         operations:
           id: operations
           table: node

--- a/web/profiles/custom/basic/config/install/views.view.content_recent.yml
+++ b/web/profiles/custom/basic/config/install/views.view.content_recent.yml
@@ -1,0 +1,320 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - user
+id: content_recent
+label: 'Recent content'
+module: node
+description: 'Recent content.'
+tag: default
+base_table: node_field_data
+base_field: nid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'Recent content'
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            trim: false
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          type: string
+          settings:
+            link_to_entity: true
+        changed:
+          id: changed
+          table: node_field_data
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: changed
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp_ago
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 10
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: 'No content available.'
+          tokenize: false
+      sorts:
+        changed:
+          id: changed
+          table: node_field_data
+          field: changed
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: changed
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: changed
+          exposed: false
+          granularity: second
+      arguments: {  }
+      filters:
+        status_extra:
+          id: status_extra
+          table: node_field_data
+          field: status_extra
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          plugin_id: node_status
+          operator: '='
+          value: false
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
+          operator: in
+          value:
+            '***LANGUAGE_language_content***': '***LANGUAGE_language_content***'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      style:
+        type: html_list
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          type: ul
+          wrapper_class: item-list
+          class: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships:
+        uid:
+          id: uid
+          table: node_field_data
+          field: uid
+          relationship: none
+          group_type: group
+          admin_label: author
+          entity_type: node
+          entity_field: uid
+          plugin_id: standard
+          required: true
+      use_more: false
+      use_more_always: false
+      use_more_text: More
+      link_display: '0'
+      link_url: ''
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  block_1:
+    id: block_1
+    display_title: Block
+    display_plugin: block
+    position: 1
+    display_options:
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }

--- a/web/profiles/custom/basic/config/install/views.view.files.yml
+++ b/web/profiles/custom/basic/config/install/views.view.files.yml
@@ -332,6 +332,15 @@ display:
             date_format: medium
             custom_date_format: ''
             timezone: ''
+            tooltip:
+              date_format: ''
+              custom_date_format: ''
+            time_diff:
+              enabled: false
+              future_format: '@interval hence'
+              past_format: '@interval ago'
+              granularity: 2
+              refresh: 60
         changed:
           id: changed
           table: file_managed
@@ -388,6 +397,15 @@ display:
             date_format: medium
             custom_date_format: ''
             timezone: ''
+            tooltip:
+              date_format: ''
+              custom_date_format: ''
+            time_diff:
+              enabled: false
+              future_format: '@interval hence'
+              past_format: '@interval ago'
+              granularity: 2
+              refresh: 60
         count:
           id: count
           table: file_usage
@@ -1020,7 +1038,6 @@ display:
           default_argument_type: fixed
           default_argument_options:
             argument: ''
-          default_argument_skip_url: false
           summary_options:
             base_path: ''
             count: true

--- a/web/profiles/custom/basic/config/install/views.view.glossary.yml
+++ b/web/profiles/custom/basic/config/install/views.view.glossary.yml
@@ -1,16 +1,18 @@
 langcode: en
-status: true
+status: false
 dependencies:
+  config:
+    - system.menu.main
   module:
-    - block_content
+    - node
     - user
-id: block_content
-label: 'Custom block library'
-module: views
-description: 'Find and manage custom blocks.'
+id: glossary
+label: Glossary
+module: node
+description: 'All content, by letter.'
 tag: default
-base_table: block_content_field_data
-base_field: id
+base_table: node_field_data
+base_field: nid
 display:
   default:
     id: default
@@ -18,19 +20,18 @@ display:
     display_plugin: default
     position: 0
     display_options:
-      title: 'Custom block library'
       fields:
-        info:
-          id: info
-          table: block_content_field_data
-          field: info
+        title:
+          id: title
+          table: node_field_data
+          field: title
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: null
-          entity_field: info
+          entity_type: node
+          entity_field: title
           plugin_id: field
-          label: 'Block description'
+          label: Title
           exclude: false
           alter:
             alter_text: false
@@ -71,31 +72,17 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          click_sort_column: value
-          type: string
-          settings:
-            link_to_entity: true
-          group_column: value
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
-        type:
-          id: type
-          table: block_content_field_data
-          field: type
-          relationship: none
+        name:
+          id: name
+          table: users_field_data
+          field: name
+          relationship: uid
           group_type: group
           admin_label: ''
-          entity_type: block_content
-          entity_field: type
+          entity_type: user
+          entity_field: name
           plugin_id: field
-          label: 'Block type'
+          label: Author
           exclude: false
           alter:
             alter_text: false
@@ -136,31 +123,18 @@ display:
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
-          click_sort_column: target_id
-          type: entity_reference_label
-          settings:
-            link: false
-          group_column: target_id
-          group_columns: {  }
-          group_rows: true
-          delta_limit: 0
-          delta_offset: 0
-          delta_reversed: false
-          delta_first_last: false
-          multi_type: separator
-          separator: ', '
-          field_api_classes: false
+          type: user_name
         changed:
           id: changed
-          table: block_content_field_data
+          table: node_field_data
           field: changed
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: block_content
+          entity_type: node
           entity_field: changed
           plugin_id: field
-          label: Updated
+          label: 'Last update'
           exclude: false
           alter:
             alter_text: false
@@ -203,11 +177,11 @@ display:
           hide_alter_empty: true
           type: timestamp
           settings:
-            date_format: short
+            date_format: long
             custom_date_format: ''
             timezone: ''
             tooltip:
-              date_format: ''
+              date_format: long
               custom_date_format: ''
             time_diff:
               enabled: false
@@ -215,67 +189,16 @@ display:
               past_format: '@interval ago'
               granularity: 2
               refresh: 60
-        operations:
-          id: operations
-          table: block_content
-          field: operations
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: block_content
-          plugin_id: entity_operations
-          label: Operations
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          destination: true
       pager:
         type: mini
         options:
           offset: 0
-          items_per_page: 50
-          total_pages: null
+          items_per_page: 36
+          total_pages: 0
           id: 0
           tags:
-            next: 'Next ›'
-            previous: '‹ Previous'
+            next: ››
+            previous: ‹‹
           expose:
             items_per_page: false
             items_per_page_label: 'Items per page'
@@ -288,7 +211,7 @@ display:
         type: basic
         options:
           submit_button: Apply
-          reset_button: true
+          reset_button: false
           reset_button_label: Reset
           exposed_sorts_label: 'Sort by'
           expose_sort_order: true
@@ -297,133 +220,72 @@ display:
       access:
         type: perm
         options:
-          perm: 'administer blocks'
+          perm: 'access content'
       cache:
         type: tag
         options: {  }
-      empty:
-        area_text_custom:
-          id: area_text_custom
-          table: views
-          field: area_text_custom
-          relationship: none
-          group_type: group
-          admin_label: ''
-          plugin_id: text_custom
-          empty: true
-          content: 'There are no custom blocks available.'
-          tokenize: false
-        block_content_listing_empty:
-          id: block_content_listing_empty
-          table: block_content
-          field: block_content_listing_empty
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: block_content
-          plugin_id: block_content_listing_empty
-          label: ''
-          empty: true
+      empty: {  }
       sorts: {  }
-      arguments: {  }
-      filters:
-        info:
-          id: info
-          table: block_content_field_data
-          field: info
+      arguments:
+        title:
+          id: title
+          table: node_field_data
+          field: title
           relationship: none
           group_type: group
           admin_label: ''
-          entity_type: block_content
-          entity_field: info
+          entity_type: node
+          entity_field: title
           plugin_id: string
-          operator: contains
-          value: ''
-          group: 1
-          exposed: true
-          expose:
-            operator_id: info_op
-            label: 'Block description'
-            description: ''
-            use_operator: false
-            operator: info_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: info
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-        type:
-          id: type
-          table: block_content_field_data
-          field: type
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: block_content
-          entity_field: type
-          plugin_id: bundle
-          operator: in
-          value: {  }
-          group: 1
-          exposed: true
-          expose:
-            operator_id: type_op
-            label: 'Block type'
-            description: ''
-            use_operator: false
-            operator: type_op
-            operator_limit_selection: false
-            operator_list: {  }
-            identifier: type
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-              anonymous: '0'
-              administrator: '0'
-            reduce: false
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-        reusable:
-          id: reusable
-          table: block_content_field_data
-          field: reusable
-          relationship: none
-          group_type: group
-          admin_label: ''
-          entity_type: block_content
-          entity_field: reusable
+          default_action: default
+          exception:
+            title_enable: true
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: a
+          summary_options: {  }
+          summary:
+            format: default_summary
+          specify_validation: true
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          glossary: true
+          limit: 1
+          case: upper
+          path_case: lower
+          transform_dash: false
+          break_phrase: false
+      filters:
+        status:
+          id: status
+          table: node_field_data
+          field: status
+          entity_type: node
+          entity_field: status
           plugin_id: boolean
-          operator: '='
           value: '1'
+          group: 1
+          expose:
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+        langcode:
+          id: langcode
+          table: node_field_data
+          field: langcode
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: langcode
+          plugin_id: language
+          operator: in
+          value:
+            '***LANGUAGE_language_content***': '***LANGUAGE_language_content***'
           group: 1
           exposed: false
           expose:
@@ -440,6 +302,7 @@ display:
             multiple: false
             remember_roles:
               authenticated: authenticated
+            reduce: false
           is_grouped: false
           group_info:
             label: ''
@@ -458,49 +321,34 @@ display:
           grouping: {  }
           row_class: ''
           default_row_class: true
+          uses_fields: false
           columns:
-            info: info
-            type: type
+            title: title
+            name: name
             changed: changed
-            operations: operations
-          default: changed
+          default: title
           info:
-            info:
+            title:
               sortable: true
-              default_sort_order: asc
-              align: ''
               separator: ''
-              empty_column: false
-              responsive: ''
-            type:
+            name:
               sortable: true
-              default_sort_order: asc
-              align: ''
               separator: ''
-              empty_column: false
-              responsive: ''
             changed:
               sortable: true
-              default_sort_order: desc
-              align: ''
               separator: ''
-              empty_column: false
-              responsive: ''
-            operations:
-              sortable: false
-              default_sort_order: asc
-              align: ''
-              separator: ''
-              empty_column: false
-              responsive: ''
           override: true
           sticky: false
           summary: ''
-          empty_table: true
-          caption: ''
-          description: ''
+          order: asc
+          empty_table: false
       row:
         type: fields
+        options:
+          default_field_elements: true
+          inline: {  }
+          separator: ''
+          hide_empty: false
       query:
         type: views_query
         options:
@@ -509,7 +357,17 @@ display:
           distinct: false
           replica: false
           query_tags: {  }
-      relationships: {  }
+      relationships:
+        uid:
+          id: uid
+          table: node_field_data
+          field: uid
+          relationship: none
+          group_type: group
+          admin_label: author
+          plugin_id: standard
+          required: false
+      use_ajax: true
       header: {  }
       footer: {  }
       display_extenders: {  }
@@ -520,6 +378,74 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - 'user.node_grants:view'
+        - user.permissions
+      tags: {  }
+  attachment_1:
+    id: attachment_1
+    display_title: Attachment
+    display_plugin: attachment
+    position: 2
+    display_options:
+      pager:
+        type: none
+        options:
+          offset: 0
+          items_per_page: 0
+      arguments:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: node
+          entity_field: title
+          plugin_id: string
+          default_action: summary
+          exception:
+            title_enable: true
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: a
+          summary_options:
+            items_per_page: 25
+            inline: true
+            separator: ' | '
+          summary:
+            format: unformatted_summary
+          specify_validation: true
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          glossary: true
+          limit: 1
+          case: upper
+          path_case: lower
+          transform_dash: false
+          break_phrase: false
+      query:
+        type: views_query
+        options: {  }
+      defaults:
+        arguments: false
+      display_extenders: {  }
+      displays:
+        default: default
+        page_1: page_1
+      inherit_arguments: false
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - 'user.node_grants:view'
         - user.permissions
       tags: {  }
   page_1:
@@ -528,16 +454,17 @@ display:
     display_plugin: page
     position: 1
     display_options:
+      query:
+        type: views_query
+        options: {  }
       display_extenders: {  }
-      path: admin/structure/block/block-content
+      path: glossary
       menu:
-        type: tab
-        title: 'Custom block library'
-        description: ''
+        type: normal
+        title: Glossary
         weight: 0
-        menu_name: admin
-        parent: block.admin_display
-        context: '0'
+        menu_name: main
+        parent: ''
     cache_metadata:
       max-age: -1
       contexts:
@@ -545,5 +472,6 @@ display:
         - 'languages:language_interface'
         - url
         - url.query_args
+        - 'user.node_grants:view'
         - user.permissions
       tags: {  }

--- a/web/profiles/custom/basic/config/install/views.view.who_s_new.yml
+++ b/web/profiles/custom/basic/config/install/views.view.who_s_new.yml
@@ -1,0 +1,194 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - user
+id: who_s_new
+label: "Who's new"
+module: user
+description: 'Shows a list of the newest user accounts on the site.'
+tag: default
+base_table: users_field_data
+base_field: uid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: "Who's new"
+      fields:
+        name:
+          id: name
+          table: users_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: user
+          entity_field: name
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            trim: false
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          type: user_name
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 5
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts:
+        created:
+          id: created
+          table: users_field_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: user
+          entity_field: created
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: created
+          exposed: false
+          granularity: second
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: users_field_data
+          field: status
+          entity_type: user
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: '0'
+            operator_limit_selection: false
+            operator_list: {  }
+        access:
+          id: access
+          table: users_field_data
+          field: access
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: user
+          entity_field: access
+          plugin_id: date
+          operator: '>'
+          value:
+            min: ''
+            max: ''
+            value: '1970-01-01'
+            type: date
+          group: 1
+          exposed: false
+          expose:
+            operator_id: '0'
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      style:
+        type: html_list
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user.permissions
+      tags: {  }
+  block_1:
+    id: block_1
+    display_title: "Who's new"
+    display_plugin: block
+    position: 1
+    display_options:
+      display_description: 'A list of new users'
+      display_extenders: {  }
+      block_description: "Who's new"
+      block_category: User
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user.permissions
+      tags: {  }

--- a/web/profiles/custom/basic/config/install/views.view.who_s_online.yml
+++ b/web/profiles/custom/basic/config/install/views.view.who_s_online.yml
@@ -1,0 +1,223 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - user
+id: who_s_online
+label: "Who's online block"
+module: user
+description: 'Shows the user names of the most recently active users, and the total number of active users.'
+tag: default
+base_table: users_field_data
+base_field: uid
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: "Who's online"
+      fields:
+        name:
+          id: name
+          table: users_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: user
+          entity_field: name
+          plugin_id: field
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            make_link: false
+            absolute: false
+            word_boundary: false
+            ellipsis: false
+            strip_tags: false
+            trim: false
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          type: user_name
+      pager:
+        type: some
+        options:
+          offset: 0
+          items_per_page: 10
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'access user profiles'
+      cache:
+        type: tag
+        options: {  }
+      empty:
+        area_text_custom:
+          id: area_text_custom
+          table: views
+          field: area_text_custom
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text_custom
+          empty: true
+          content: 'There are currently 0 users online.'
+          tokenize: false
+      sorts:
+        access:
+          id: access
+          table: users_field_data
+          field: access
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: user
+          entity_field: access
+          plugin_id: date
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: access
+          exposed: false
+          granularity: second
+      arguments: {  }
+      filters:
+        status:
+          id: status
+          table: users_field_data
+          field: status
+          entity_type: user
+          entity_field: status
+          plugin_id: boolean
+          value: '1'
+          group: 1
+          expose:
+            operator: '0'
+            operator_limit_selection: false
+            operator_list: {  }
+        access:
+          id: access
+          table: users_field_data
+          field: access
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: user
+          entity_field: access
+          plugin_id: date
+          operator: '>='
+          value:
+            min: ''
+            max: ''
+            value: '-15 minutes'
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: access_op
+            label: 'Last access'
+            description: 'A user is considered online for this long after they have last viewed a page.'
+            use_operator: false
+            operator: access_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: access
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      style:
+        type: html_list
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          type: ul
+          wrapper_class: item-list
+          class: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header:
+        result:
+          id: result
+          table: views
+          field: result
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: result
+          empty: false
+          content: 'There are currently @total users online.'
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user.permissions
+      tags: {  }
+  who_s_online_block:
+    id: who_s_online_block
+    display_title: "Who's online"
+    display_plugin: block
+    position: 1
+    display_options:
+      display_description: 'A list of users that are currently logged in.'
+      display_extenders: {  }
+      block_description: "Who's online"
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - user.permissions
+      tags: {  }


### PR DESCRIPTION
Ticket: WD-254

## Changes

- WD-254: Upgrade Drupal core to 10.2.5, update other Composer packages.
- WD-254: Update `basic` profile.

## Todo

I see no value in a custom `basic` profile.  We should move to `minimal` profile and move the configuration to `config/sync` instead. We have the configuration sync directory path defined in `settings.php` and the status page shows the error mesage _The `../config/sync` folder does not exist._

Maintaining custom profile configuration changes requires more work than regular configuration updates via `drush cex`.

I was using the following commands to clean up the profile config from `uuid:` & `_core:` keys: 

```sh
find web/profiles/custom/basic/config/install/ -type f -exec sed -i '' '/^uuid: /d' {} \;
find web/profiles/custom/basic/config/install/ -type f -exec sed -i '' '/_core:/{N;d;}' {} \;
```

## Testing

1. Install the site by running the following command: `lando drush si basic`.
2. Run `lando drush deploy` and make sure that Composer packages are upgraded.