### PR TITLE
WD-254: Update Lando to v3.21

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -6,7 +6,6 @@ config:
   via: nginx
   webroot: web
   database: "mariadb:10.6"
-  composer_version: 2
   xdebug: off
   config:
     php: .lando/php.ini
@@ -159,4 +158,4 @@ env_file:
   # - .env
 
 # Tested with Lando version
-version: v3.20.4
+version: v3.21

--- a/.lando.yml
+++ b/.lando.yml
@@ -125,17 +125,17 @@ services:
     type: "node:20"
     build:
       - "npm install"
-  # varnish:
-  #   type: "varnish:6"
-  #   backends:
-  #     - appserver_nginx
-  #   config:
-  #     vcl: .lando/varnish.vcl
-  #   ssl: true
-  #   overrides:
-  #     environment:
-  #       ADMIN_PORT: ":6082"
-  #       VARNISH_ALLOW_UNRESTRICTED_PURGE: "true"
+  varnish:
+    type: "varnish:6"
+    backends:
+      - appserver_nginx
+    config:
+      vcl: .lando/varnish.vcl
+    ssl: true
+    overrides:
+      environment:
+        ADMIN_PORT: ":6082"
+        VARNISH_ALLOW_UNRESTRICTED_PURGE: "true"
 
 proxy:
   adminer:
@@ -146,8 +146,8 @@ proxy:
   #   - elasticsearch.lndo.site:9200
   # kibana:
   #   - kibana.lndo.site:5601
-  # varnish:
-  #   - varnish.drupal-project.lndo.site
+  varnish:
+    - varnish.drupal-project.lndo.site
 
 events:
   post-db-import:

--- a/.lando.yml
+++ b/.lando.yml
@@ -5,7 +5,7 @@ config:
   php: "8.2"
   via: nginx
   webroot: web
-  database: "mariadb:10.3"
+  database: "mariadb:10.6"
   composer_version: 2
   xdebug: off
   config:


### PR DESCRIPTION
Ticket: WD-254

## Changes

- WD-254: Enable local Varnish service to match the Silta environments.
- WD-254: Update local MariaDB to v10.6.
- WD-254: Update Lando to v3.21.
