### PR TITLE
QAG-44: Simplify the PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,52 +1,23 @@
-# Link to ticket: 
+## Ticket
 
-[Add link to ticket] (if automatic linking is not used)
+[Add a link to the ticket]
 
-# Changes proposed in this PR:
+## Description
 
 [Explain what was done and why. You can also add screenshots here if it helps.]
 
-# How to test
+## Testing
 
-## Testing in feature environment:
+### Feature environment
 
-[Add link to feature environment]
-https://[BRANCH-NAME].[PROJECT-NAME].dev.wdr.io/
+[Add a link to the feature environment]
 
-[Add command how to get admin login url to the feature environment]
-`ssh www-admin@[BRANCH-name]-shell.[PROJECT-NAME] -J www-admin@ssh.dev.wdr.io "drush uli"`
+Drush uli: [Add a `drush uli` command to get (admin) login url to the feature environment]
 
-## Local testing
+### Setting up local environment
 
-_Detail custom setup instructions if any - any drush commands, content reindexing, specific user to use, etc._
+[Detail custom setup instructions if any - any drush commands, content reindexing, specific user to use, etc.]
 
-    git fetch && git checkout <branch>
-    lando composer install
-    lando drush cim -y
-    lando drush cr
+### Testing instructions
 
-## Testing steps
-
-_Testing scenario goes here._
-
-1. Do this.
-2. Go there.
-3. Validate that xyz is working.
-
-# Best practices:
-
-<details>
-<summary><h3>Accessibility:</h3></summary>
-<p>
-This project must support WCAG accessibility level AA <em>(edit this according to the requirements of your project)</em>. To ensure this standard is met, remember to:
-
-- Perform automated checks using a tool such as Wave or SiteImprove.
-- Test keyboard navigation: are all parts of the UI navigable using only the keyboard? Is the tab order logical? Can popups, menus etc be dismissed with the escape key?
-- Test responsiveness, scaling and text reflow.
-- Make sure no accessibility issues exist on either desktop or mobile views.
-- If you have time, test with a screen reader such as VoiceOver (macOS), NVDA (Windows), or Orca (Linux).
-
-Use the [Accessibility Testing Cheat Sheet](https://intra.wunder.io/info/accessibility-group/accessibility-testing-cheat-sheet) for information on how to run these tests.
-
-</p>
-</details>
+[List all the steps that should be performed to test the feature]

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,23 +1,15 @@
-## Ticket
+## Ticket QAG-XXX
 
-[Add a link to the ticket]
+## Changes
 
-## Description
-
-[Explain what was done and why. You can also add screenshots here if it helps.]
+- [Explain what changes were made in this PR]
 
 ## Testing
 
-### Feature environment
+Enviroment: [Feature environment URL]
 
-[Add a link to the feature environment]
+Login: [`drush uli` command]
 
-Drush uli: [Add a `drush uli` command to get (admin) login url to the feature environment]
+Instructions:
 
-### Setting up local environment
-
-[Detail custom setup instructions if any - any drush commands, content reindexing, specific user to use, etc.]
-
-### Testing instructions
-
-[List all the steps that should be performed to test the feature]
+- [Step by step instructions to test the changes]


### PR DESCRIPTION
## Ticket QAG-44

## Description

This PR is using the new simpler template 🌿

- Removed 'Best practices' section for being redundant
- Add square brackets for all the texts that should be replaced, to make it clearer on what to update
- This template will still have the `MD041/first-line-heading/first-line-h1: First line in a file should be a top-level heading` linting error, but IMO it doesn't make any sense to add level 1 heading here just for the sake of it.

One thing I'd still consider removing is the `Setting up local environment` section, as I think those steps should be added under `Testing instructions` section, even though the instructions can be used for both local and feature environment testing.

## Testing

### Feature environment

No feature environment.

### Setting up local environment

No local environment setting up required.

### Testing instructions

See that the PR template makes sense.

