### PR TITLE
WD-245: Add MariaDB config for production environment

### DIFF
--- a/silta/silta-prod.yml
+++ b/silta/silta-prod.yml
@@ -50,10 +50,58 @@ mariadb:
     resources:
       requests:
         cpu: 250m
-        memory: 500M
+        memory: 500Mi
       limits:
         cpu: 1000m
-        memory: 750M
+        memory: 750Mi
+    config: |-
+      [mysqld]
+      skip-name-resolve
+      explicit_defaults_for_timestamp
+      basedir=/opt/bitnami/mariadb
+      plugin_dir=/opt/bitnami/mariadb/plugin
+      port=3306
+      socket=/opt/bitnami/mariadb/tmp/mysql.sock
+      tmpdir=/opt/bitnami/mariadb/tmp
+      max_allowed_packet=256M
+      bind-address=0.0.0.0
+      pid-file=/opt/bitnami/mariadb/tmp/mysqld.pid
+      log-error=/opt/bitnami/mariadb/logs/mysqld.log
+      character-set-server=UTF8
+      collation-server=utf8_unicode_ci
+      transaction-isolation=READ-COMMITTED
+      # Default max_connections value is 150.
+      # Each active connection consumes approx. 19-20MB of memory.
+      # Consider adding additional memory for production requests/limits when scaling up.
+      max_connections=200
+      # Set innodb_buffer_pool_size to 70/80% of resources.requests.memory (500Mi).
+      innodb_buffer_pool_size=375Mi
+      innodb_log_buffer_size=8M
+      # Set innodb_log_file_size to 12.5% of innodb_buffer_pool_size (47Mi is 12.5% of 375Mi).
+      innodb_log_file_size=47Mi
+      innodb_lock_wait_timeout=120
+      innodb_open_files=49152
+      innodb_flush_log_at_trx_commit=2
+      innodb_flush_method=O_DIRECT
+      table_open_cache=4000
+      table_definition_cache=1000
+      back_log=2048
+      tmp_table_size=64M
+      max_heap_table_size=32M
+      join_buffer_size=2M
+      # have_query_cache=NO
+      performance_schema=1
+      innodb_write_io_threads=16
+      innodb_use_native_aio=0
+      [client]
+      port=3306
+      socket=/opt/bitnami/mariadb/tmp/mysql.sock
+      default-character-set=UTF8
+      plugin_dir=/opt/bitnami/mariadb/plugin
+      [manager]
+      port=3306
+      socket=/opt/bitnami/mariadb/tmp/mysql.sock
+      pid-file=/opt/bitnami/mariadb/tmp/mysqld.pid
 
 # Consider enabling memcached service
 # memcached:


### PR DESCRIPTION
## Ticket WD-245

### Changes

- Add MariaDB config for production environment (https://github.com/wunderio/drupal-project/pull/407 follow-up)
