### PR TITLE
WNDR-281: Override mariadb image to get the latest patch version.

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -85,10 +85,12 @@ services:
     services:
       image: drupalci/webdriver-chromedriver:production
       command: chromedriver --log-path=/tmp/chromedriver.log --verbose --whitelisted-ips=
+  database:
   # Use random static high port for database connection.
   # @see: https://docs.lando.dev/guides/external-access.html
-  # database:
-  #   portforward: 34567
+  # portforward: 34567
+    overrides:
+      image: bitnami/mariadb:10.6-debian-12
   # elasticsearch:
   #   type: lando
   #   services:

--- a/.lando.yml
+++ b/.lando.yml
@@ -86,9 +86,9 @@ services:
       command: chromedriver --log-path=/tmp/chromedriver.log --verbose --whitelisted-ips=
   database:
     type: "mariadb:10.6.18"
-  # Use random static high port for database connection.
-  # @see: https://docs.lando.dev/guides/external-access.html
-  # portforward: 34567
+    # Assign a static port if you need to access the database from your host machine.
+    # @see: https://docs.lando.dev/guides/external-access.html
+    # portforward: 34567
   # elasticsearch:
   #   type: lando
   #   services:

--- a/.lando.yml
+++ b/.lando.yml
@@ -5,7 +5,6 @@ config:
   php: "8.2"
   via: nginx
   webroot: web
-  database: "mariadb:10.6"
   xdebug: off
   config:
     php: .lando/php.ini
@@ -86,11 +85,10 @@ services:
       image: drupalci/webdriver-chromedriver:production
       command: chromedriver --log-path=/tmp/chromedriver.log --verbose --whitelisted-ips=
   database:
+    type: "mariadb:10.6.18"
   # Use random static high port for database connection.
   # @see: https://docs.lando.dev/guides/external-access.html
   # portforward: 34567
-    overrides:
-      image: bitnami/mariadb:10.6-debian-12
   # elasticsearch:
   #   type: lando
   #   services:


### PR DESCRIPTION
Link to ticket: WNDR-281

Proposed changes:
- Override the mariadb docker image in order to get the latest patch version. This is needed at least until https://github.com/lando/mariadb/pull/56 gets merged.
- Drupal chart is also getting a similar PR: https://github.com/wunderio/drupal-project-k8s/pull/708

Testing:
- Checkout this branch
- Run `lando ssh -s database -c 'mysql --version'`, it should output `10.6.5`
- Run `lando rebuild -s database`
- Run `lando ssh -s database -c 'mysql --version'`, it should output `10.6.18`