### PR TITLE
WD-253: Upgrade wunderio/code-quality to v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,15 @@ The `silta/silta.secret` file is a YAML file that contains the encrypted secrets
 
 This project is maintained by [Wunder](https://wunder.io/). We welcome contributions from the community.
 
-Internally, we use JIRA for project management, but we also use GitHub issues for public projects.
+### Commit message validation and ticketing system integration
 
-Introduce your idea in the issue queue and prefix the pull request and commit messages with the issue key in the following format: `GH-123: Add a new feature`. In this way, the issue is automatically linked to your contribution.
+Our project uses both JIRA and GitHub Issues for tracking and managing tasks. We use [Autolinked references](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls) to convert ticket IDs into links for easy navigation. To ensure traceability, commit messages must include a valid ticket ID from either system, except for merge commits. Additionally, provide a clear description of the change.
+
+The format is as follows:
+
+- JIRA: `[PROJECTKEY-123]: Description`
+- GitHub: `[GH-123]: Description`
+
+Validation rules are implemented via GrumPHP `git_commit_message` component. Please see `grumphp.yml` for details.
+
+Following these guidelines ensures our project remains organized and changes are traceable. Thank you for adhering to these standards.

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     },
     "require-dev": {
         "drupal/core-dev": "^10.2",
-        "wunderio/code-quality": "^2.4"
+        "wunderio/code-quality": "^3.0"
     },
     "conflict": {
         "drupal/drupal": "*"

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -7,6 +7,7 @@ grumphp:
     failed: ~
     succeeded: ~
   tasks:
+    # @see: https://github.com/phpro/grumphp/blob/v2.x/doc/tasks/git_commit_message.md
     git_commit_message:
       max_body_width: 0
       max_subject_width: 0


### PR DESCRIPTION
## Ticket WD-253

## Problem

Current setup doesn't allow committing merge commits because of ticket ID validation rules.

## Changes
- WD-253: Upgrade wunderio/code-quality to v3. This enables `skip_on_merge_commit: true` feature (on by default) for [GrumPHP git_commit_message](https://github.com/phpro/grumphp/blob/v2.x/doc/tasks/git_commit_message.md) plugin.
- WD-253: Add Ticketing System Integration section to the readme

## Testing

Try to successfully commit some merge commit.
