### PR TITLE
WD-265: Add lando drupal tool

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -15,6 +15,10 @@ tooling:
     description: "Runs Composer commands"
     cmd:
       - appserver: /usr/local/bin/composer
+  drupal:
+    description: "Runs Drupal core script with provided arguments"
+    cmd:
+      - appserver: /app/.lando/drupal.sh
   grumphp:
     description: "Runs grumphp commands"
     cmd:

--- a/.lando/drupal.sh
+++ b/.lando/drupal.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+## Description: run the Drupal core script with provided arguments
+## Usage: drupal <arguments>
+## Example: lando drupal generate-theme my-theme
+
+cd ${LANDO_WEBROOT}
+
+php core/scripts/drupal "$@"

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The following secret variables are defined in the file `silta/silta.secret` for 
 ### [Tools](https://docs.lando.dev/core/v3/tooling.html)
 
 - `lando` - tools / commands overview.
+- `lando drupal <arguments>` - run the Drupal core script with provided arguments.
 - `lando grumphp <commands>` - run [GrumPHP](https://github.com/phpro/grumphp) code quality checks. Modified or new files are checked on git commit, see more at `lando grumphp -h` or [wunderio/code-quality](https://github.com/wunderio/code-quality).
 - `lando npm <commands>` - run [npm](https://www.npmjs.com/) commands.
 - `lando phpunit <commands>` - run [PHPUnit](https://phpunit.de/) commands.


### PR DESCRIPTION
## Ticket WD-265

## Changes

- WD-265: Add lando drupal tool which runs Drupal core script with provided arguments. Usage: `lando drupal <arguments>`.

## Testing

Try to run `lando drupal generate-theme my-theme`.