### PR TITLE
SLT-1052: Upgrade PHP to v8.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,9 @@ orbs:
   silta: silta/silta@1
 
 executors:
-  cicd82:
+  cicd83:
     docker:
-      - image: wunderio/silta-cicd:circleci-php8.2-node22-composer2-v1
+      - image: wunderio/silta-cicd:circleci-php8.3-node22-composer2-v1
 
 workflows:
   commit:
@@ -23,7 +23,7 @@ workflows:
 
       - silta/drupal-validate:
           name: validate
-          executor: cicd82
+          executor: cicd83
           post-validation:
             - run: echo "You can add additional validation here!"
 
@@ -36,7 +36,7 @@ workflows:
       # Other jobs defined below extend this job.
       - silta/drupal-build: &build
           name: build
-          executor: cicd82
+          executor: cicd83
           codebase-build:
             - silta/drupal-composer-install
             - silta/npm-install-build
@@ -56,7 +56,7 @@ workflows:
       # Other jobs defined below extend this job.
       - silta/drupal-deploy: &deploy
           name: deploy
-          executor: cicd82
+          executor: cicd83
           silta_config: silta/silta.yml,silta/silta.secret
           pre-release:
             - silta/decrypt-files:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
   silta: silta/silta@1
 
 executors:
-  cicd83:
+  silta:
     docker:
       - image: wunderio/silta-cicd:circleci-php8.3-node22-composer2-v1
 
@@ -23,7 +23,7 @@ workflows:
 
       - silta/drupal-validate:
           name: validate
-          executor: cicd83
+          executor: silta
           post-validation:
             - run: echo "You can add additional validation here!"
 
@@ -36,7 +36,7 @@ workflows:
       # Other jobs defined below extend this job.
       - silta/drupal-build: &build
           name: build
-          executor: cicd83
+          executor: silta
           codebase-build:
             - silta/drupal-composer-install
             - silta/npm-install-build
@@ -56,7 +56,7 @@ workflows:
       # Other jobs defined below extend this job.
       - silta/drupal-deploy: &deploy
           name: deploy
-          executor: cicd83
+          executor: silta
           silta_config: silta/silta.yml,silta/silta.secret
           pre-release:
             - silta/decrypt-files:

--- a/.lando.yml
+++ b/.lando.yml
@@ -2,7 +2,7 @@ name: drupal-project
 recipe: drupal10
 
 config:
-  php: "8.2"
+  php: "8.3"
   via: nginx
   webroot: web
   xdebug: off

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.3",
         "composer/installers": "^2.2",
         "cweagans/composer-patches": "^1.7",
         "drupal/admin_toolbar": "^3.4",

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,13 @@
     ],
     "require": {
         "php": ">=8.3",
-        "composer/installers": "^2.2",
+        "composer/installers": "^2.3",
         "cweagans/composer-patches": "^1.7",
-        "drupal/admin_toolbar": "^3.4",
-        "drupal/core-composer-scaffold": "^10.2",
-        "drupal/core-recommended": "^10.2",
+        "drupal/admin_toolbar": "^3.5",
+        "drupal/core-composer-scaffold": "^10.3",
+        "drupal/core-recommended": "^10.3",
         "drupal/monolog": "^3.0",
-        "drupal/purge": "^3.5",
+        "drupal/purge": "^3.6",
         "drupal/simplei": "^2.1",
         "drupal/varnish_purge": "^2.2",
         "drush/drush": "^12.5",
@@ -30,7 +30,7 @@
         "wunderio/drupal-ping": "^2.5"
     },
     "require-dev": {
-        "drupal/core-dev": "^10.2",
+        "drupal/core-dev": "^10.3",
         "wunderio/code-quality": "^3.0"
     },
     "conflict": {
@@ -45,9 +45,10 @@
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "drupal/core-composer-scaffold": true,
             "koodimonni/composer-dropin-installer": true,
+            "php-http/discovery": true,
             "phpro/grumphp": true,
             "phpstan/extension-installer": true,
-            "php-http/discovery": true
+            "tbachert/spi": true
         },
         "discard-changes": true,
         "process-timeout": 0,

--- a/silta/php.Dockerfile
+++ b/silta/php.Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for the PHP container.
-FROM wunderio/silta-php-fpm:8.2-fpm-v1
+FROM wunderio/silta-php-fpm:8.3-fpm-v1
 
 COPY --chown=www-data:www-data . /app
 

--- a/silta/shell.Dockerfile
+++ b/silta/shell.Dockerfile
@@ -1,4 +1,4 @@
 # Dockerfile for the Shell container.
-FROM wunderio/silta-php-shell:php8.2-v1
+FROM wunderio/silta-php-shell:php8.3-v1
 
 COPY --chown=www-data:www-data . /app


### PR DESCRIPTION
## Ticket: [SLT-1052](https://wunder.atlassian.net/browse/SLT-1052)

## Changes

- SLT-1052: Upgrade PHP to v8.3 in all environments.
- SLT-1052: Use default naming convention for CI executors.
- SLT-1052: Bumping Composer package versions (incl. Drupal core to v10.3).

[SLT-1052]: https://wunder.atlassian.net/browse/SLT-1052?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ