### PR TITLE
QAG-34: Update CI config documentation with learnings from TKU-1003

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,6 +65,10 @@ workflows:
                 # This is stored in CircleCI as an environment variable and also in LastPass.
                 secret_key_env: SEC_DRUPAL_PROJECT_SILTA_DEV
           context: silta_dev
+          # Make sure that `requires` is always set to override the default value in `main` and `production` build jobs.
+          # This is to avoid requiring the `approve-deployment` job which breaks the deployment.
+          # This is because the `main` and `production` environments are filtered out from the default `build` job.
+          # Use `requires: []` to override the default value when no other jobs are required.
           requires:
             - build
           filters:


### PR DESCRIPTION
## Ticket QAG-34

## Problem

The CI workflow breaks if you require any step in the default build job and don't override the "requires" part of the derived branches filtered out in the default job.

## Changes

- QAG-34: Update CI config documentation with learnings from TKU-1003

```yaml
# Make sure that `requires` is always set to override the default value in `main` and `production` build jobs.
# This is to avoid requiring the `approve-deployment` job which breaks the deployment.
# This is because the `main` and `production` environments are filtered out from the default `build` job.
# Use `requires: []` to override the default value when no other jobs are required.
```