### PR TITLE
QAG-30: Disable MailHog in production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,8 @@
 version: 2.1
 
 orbs:
+  # Include the Silta orb.
+  # @see https://circleci.com/developer/orbs/orb/silta/silta
   silta: silta/silta@1
 
 executors:

--- a/silta/silta-prod.yml
+++ b/silta/silta-prod.yml
@@ -41,6 +41,10 @@ nginx:
 # basicauth:
 #   enabled: false
 
+# Disable MailHog in production.
+mailhog:
+  enabled: false
+
 mariadb:
   master:
     persistence:

--- a/silta/silta-prod.yml
+++ b/silta/silta-prod.yml
@@ -1,3 +1,5 @@
+# Override the default values of Wunder's Drupal Helm chart and silta.yml.
+# @see: https://github.com/wunderio/charts/blob/master/drupal/values.yaml
 
 # Enable autoscaling for production.
 autoscaling:

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -1,8 +1,6 @@
 
-# Values in this file override the default values of our helm chart.
-#
-# See https://github.com/wunderio/charts/blob/master/drupal/values.yaml
-# for all possible options.
+# Override the default values of Wunder's Drupal Helm chart.
+# @see: https://github.com/wunderio/charts/blob/master/drupal/values.yaml
 
 php:
   drupalCoreVersion: "10"


### PR DESCRIPTION
## Ticket QAG-30

## Problem

Production release failed with the following message: `Error: execution error at (drupal/templates/checks.yaml:4:4): Mailhog should not be enabled in production`.

## Changes

- 0b034c3 QAG-30: CircleCI & Silta documentation updates
- 886660c QAG-30: Disable MailHog in production

