### PR TITLE
QAG-49: (fix) Add plugin existence check for Elasticsearch installations 

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -32,7 +32,7 @@ hooks:
     - exec: |
         plugins=(analysis-icu analysis-ukrainian)
         for plugin in "${plugins[@]}"; do
-          if ! elasticsearch-plugin list | grep -q "^$plugin$"; then
+          if ! elasticsearch-plugin list | grep -q "^$plugin\b"; then
             elasticsearch-plugin install "$plugin"
           else
             echo "Plugin $plugin is already installed"

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -29,5 +29,13 @@ corepack_enable: false
 hooks:
   post-start:
     - exec: "composer install"
-    - exec: "elasticsearch-plugin install analysis-icu analysis-ukrainian"
+    - exec: |
+        plugins=(analysis-icu analysis-ukrainian)
+        for plugin in "${plugins[@]}"; do
+          if ! elasticsearch-plugin list | grep -q "^$plugin$"; then
+            elasticsearch-plugin install "$plugin"
+          else
+            echo "Plugin $plugin is already installed"
+          fi
+        done
       service: elasticsearch

--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ This project supports two local development environments: DDEV (preferred) and L
 #### DDEV setup instructions
 
 1. Install [DDEV](https://ddev.com/get-started/)
-2. Start the environment and set up your project:
+2. Ensure Docker is running on your system
+3. Start the environment and set up your project:
 
    ```bash
    # Start the DDEV environment


### PR DESCRIPTION
## Ticket QAG-49

## Changes

- 4d034d9 QAG-49: (docs) Add Docker prerequisite to DDEV setup instructions
- 3d02fc0 QAG-49: (fix) Add plugin existence check for Elasticsearch installations

