### PR TITLE
QAG-30: (feat!) Upgrade from Drupal 10 to Drupal 11

### DIFF
--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,5 +1,5 @@
 name: drupal-project
-type: drupal
+type: drupal11
 docroot: web
 php_version: "8.3"
 webserver_type: nginx-fpm
@@ -8,7 +8,7 @@ additional_hostnames: []
 additional_fqdns: []
 database:
   type: mariadb
-  version: "10.11"
+  version: "10.6"
 use_dns_when_possible: true
 composer_version: "2"
 nodejs_version: "20"

--- a/.lando.yml
+++ b/.lando.yml
@@ -1,5 +1,5 @@
 name: drupal-project
-recipe: drupal10
+recipe: drupal11
 
 config:
   php: "8.3"
@@ -96,7 +96,7 @@ services:
       image: drupalci/webdriver-chromedriver:production
       command: chromedriver --log-path=/tmp/chromedriver.log --verbose --whitelisted-ips=
   database:
-    type: "mariadb:10.6.18"
+    type: "mariadb:10.6.20"
     # Assign a static port if you need to access the database from your host machine.
     # @see: https://docs.lando.dev/guides/external-access.html
     # portforward: 34567

--- a/.lando/.env
+++ b/.lando/.env
@@ -1,6 +1,6 @@
 # Inject additional environment variables into every Lando service
 # @see: https://docs.lando.dev/config/env.html#environment-files
-DB_NAME=drupal10
-DB_USER=drupal10
-DB_PASS=drupal10
+DB_NAME=drupal11
+DB_USER=drupal11
+DB_PASS=drupal11
 DB_HOST=database

--- a/.lando/adminer.php
+++ b/.lando/adminer.php
@@ -15,7 +15,7 @@ function adminer_object()
      * Overwrite top left 'logo' link to landing page of Adminer app.
      *
      * By default, it would open link to Adminer home page. Let's also preselect
-     * Drupal 10 db.
+     * Drupal db.
      */
     function name() {
       return '<a href="' . '/?username=&db=' . getenv('DB_NAME') . '" id="h1">Adminer</a>';
@@ -47,7 +47,7 @@ function adminer_object()
       Adminer::loginForm();
       $original_form = ob_get_clean();
 
-      // Preselect Drupal 10 db.
+      // Preselect Drupal db.
       $original_form = str_replace('name="auth[db]" value=""', 'name="auth[db]" value="' . getenv('DB_NAME') . '"', $original_form);
 
       // Add id attribute to the submit button to target it with js in next

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "wunderio/drupal-project",
-    "description": "Wunder's template for Drupal 10 projects.",
+    "description": "Wunder's template for Drupal projects.",
     "type": "project",
     "license": "GPL-2.0-or-later",
     "homepage": "https://www.drupal.org/project/drupal",
@@ -19,18 +19,18 @@
         "composer/installers": "^2.3",
         "cweagans/composer-patches": "^1.7",
         "drupal/admin_toolbar": "^3.5",
-        "drupal/core-composer-scaffold": "^10.4",
-        "drupal/core-recommended": "^10.4",
+        "drupal/core-composer-scaffold": "^11.1",
+        "drupal/core-recommended": "^11.1",
         "drupal/monolog": "^3.0",
         "drupal/purge": "^3.6",
-        "drupal/simplei": "^2.1",
-        "drupal/varnish_purge": "^2.2",
+        "drupal/simplei": "^3.0",
+        "drupal/varnish_purge": "^2.3",
         "drush/drush": "^13.3",
         "vlucas/phpdotenv": "^5.6",
         "wunderio/drupal-ping": "^2.5"
     },
     "require-dev": {
-        "drupal/core-dev": "^10.4",
+        "drupal/core-dev": "^11.1",
         "wunderio/code-quality": "^3.0"
     },
     "conflict": {

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -17,7 +17,7 @@ grumphp:
         'The commit must start with the JIRA or GitHub issue number': '/^[A-Z][A-Z0-9_]+-[1-9][0-9]*: /'
     php_compatibility:
       run_on: '%grumphp.run_on_paths%'
-      testVersion: '8.2'
+      testVersion: '8.3'
     check_file_permissions: ~
     php_check_syntax:
       run_on: '%grumphp.run_on_paths%'

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -3,9 +3,6 @@
 <ruleset name="Drupal Custom">
     <description>Drupal coding standard</description>
 
-    <!-- Set ignore warnings. -->
-    <!-- <config name="ignore_warnings_on_exit" value="1" />  -->
-
     <file>.</file>
 
     <!-- exclude vendor code -->

--- a/recipes/.gitignore
+++ b/recipes/.gitignore
@@ -1,0 +1,1 @@
+/README.txt

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -4,7 +4,7 @@
 # @see: https://github.com/wunderio/charts/blob/master/drupal/values.yaml
 
 php:
-  drupalCoreVersion: "10"
+  drupalCoreVersion: "11"
   cron:
     drupal:
       # Disable cron jobs in feature environments by using non-existing date.

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -32,9 +32,6 @@ $settings['config_sync_directory'] = '../config/sync';
 // @see: https://github.com/wunderio/charts/blob/master/drupal/files/silta.services.yml
 $settings['container_yamls'][] = DRUPAL_ROOT . '/sites/services.yml';
 
-// Enable state cache for Drupal 10 performance
-$settings['state_cache'] = TRUE;
-
 // The default list of directories that will be ignored by Drupal's file API.
 $settings['file_scan_ignore_directories'] = [
   'node_modules',


### PR DESCRIPTION
## Ticket QAG-30

## Changes

- Update Drupal core and dependencies to version 11.1
- Update local development environments (DDEV and Lando) to use Drupal 11
- Update MariaDB version to 10.6.20 in Lando
- Update PHP compatibility check to PHP 8.3
- Remove Drupal 10 specific state cache setting
- Update database credentials to reflect Drupal 11
- Clean up phpcs.xml configuration
- Add recipes/.gitignore
- Make Adminer documentation version agnostic

Refs: .lando.yml, composer.json, grumphp.yml, phpcs.xml, .ddev/config.yaml, .lando/.env, .lando/adminer.php, silta/silta.yml, web/sites/default/settings.php, recipes/.gitignore

## Testing

Enviroment: https://feature-qag-30.drupal-project.dev.wdr.io

Login: [`drush uli` command]

Instructions:

- [Step by step instructions to test the changes]
