### PR TITLE
QAG-65: Development environment configuration improvements and fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,15 +12,15 @@ executors:
 
 # Define shared branch filters as reusable anchors.
 branch-filters:
-  &ignored-branches
-  branches:
-    ignore:
-      - production
-      - main
-      - /dependabot\/.*/
-      # Remove the following filters from actual project configuration.
-      - /^10\..*/
-      - /^11\..*/
+  ignored-branches: &ignored-branches
+    branches:
+      ignore:
+        - production
+        - main
+        - /dependabot\/.*/
+        # Remove the following filters from actual project configuration.
+        - /^10\..*/
+        - /^11\..*/
 
 workflows:
   commit:

--- a/.ddev/addon-metadata/elasticsearch/manifest.yaml
+++ b/.ddev/addon-metadata/elasticsearch/manifest.yaml
@@ -1,9 +1,9 @@
 name: elasticsearch
 repository: ddev/ddev-elasticsearch
 version: v0.3.2
-install_date: "2024-08-13T10:51:11+03:00"
+install_date: "2025-03-21T10:53:19+02:00"
 project_files:
-    - elasticsearch/config/elasticsearch8.yml
+    - elasticsearch/
     - docker-compose.elasticsearch8.yaml
 global_files: []
 removal_actions: []

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -33,13 +33,10 @@ hooks:
   post-start:
     - exec: "composer install"
     - exec: "npm ci"
-    - exec: |
-        plugins=(analysis-icu)
-        for plugin in "${plugins[@]}"; do
-          if ! elasticsearch-plugin list | grep -q "^$plugin\b"; then
-            elasticsearch-plugin install "$plugin"
-          else
-            echo "Plugin $plugin is already installed"
-          fi
-        done
-      service: elasticsearch
+    - exec-host: "ddev exec -s elasticsearch /mnt/ddev_config/elasticsearch/elasticsearch-setup.sh"
+    - exec-host: |
+        if [ -f /tmp/elasticsearch_needs_restart ]; then
+          echo "Restarting Elasticsearch to apply plugin changes..."
+          ddev restart elasticsearch
+          rm /tmp/elasticsearch_needs_restart
+        fi

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -33,10 +33,13 @@ hooks:
   post-start:
     - exec: "composer install"
     - exec: "npm ci"
-    - exec-host: "ddev exec -s elasticsearch /mnt/ddev_config/elasticsearch/elasticsearch-setup.sh"
     - exec-host: |
-        if [ -f /tmp/elasticsearch_needs_restart ]; then
-          echo "Restarting Elasticsearch to apply plugin changes..."
-          ddev restart elasticsearch
-          rm /tmp/elasticsearch_needs_restart
+        # Run the Elasticsearch plugin setup script
+        ddev exec -s elasticsearch /mnt/ddev_config/elasticsearch/elasticsearch-setup.sh
+
+        # Check for the restart marker file
+        if [ -f .ddev/elasticsearch/restart_needed ]; then
+          echo "Elasticsearch plugins installed. Restarting elasticsearch container..."
+          docker restart ddev-${DDEV_SITENAME}-elasticsearch
+          rm .ddev/elasticsearch/restart_needed
         fi

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -26,6 +26,7 @@ web_environment:
   - ELASTICSEARCH_HOST=elasticsearch
   - VARNISH_ADMIN_HOST=varnish
   - VARNISH_ADMIN_PORT=80
+  - SMTP_ADDRESS=localhost:1025
 
 corepack_enable: false
 hooks:

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -32,6 +32,7 @@ corepack_enable: false
 hooks:
   post-start:
     - exec: "composer install"
+    - exec: "npm install"
     - exec: |
         plugins=(analysis-icu analysis-ukrainian)
         for plugin in "${plugins[@]}"; do

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -34,7 +34,7 @@ hooks:
     - exec: "composer install"
     - exec: "npm install"
     - exec: |
-        plugins=(analysis-icu analysis-ukrainian)
+        plugins=(analysis-icu)
         for plugin in "${plugins[@]}"; do
           if ! elasticsearch-plugin list | grep -q "^$plugin\b"; then
             elasticsearch-plugin install "$plugin"

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -32,7 +32,7 @@ corepack_enable: false
 hooks:
   post-start:
     - exec: "composer install"
-    - exec: "npm install"
+    - exec: "npm ci"
     - exec: |
         plugins=(analysis-icu)
         for plugin in "${plugins[@]}"; do

--- a/.ddev/docker-compose.elasticsearch8.yaml
+++ b/.ddev/docker-compose.elasticsearch8.yaml
@@ -14,6 +14,7 @@ services:
       - VIRTUAL_HOST=$DDEV_HOSTNAME
       - HTTP_EXPOSE=9200:9200
       - HTTPS_EXPOSE=9201:9200
+      - ELASTICSEARCH_PLUGINS=analysis-icu
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.approot: $DDEV_APPROOT

--- a/.ddev/elasticsearch/config/elasticsearch8.yml
+++ b/.ddev/elasticsearch/config/elasticsearch8.yml
@@ -1,4 +1,3 @@
-#ddev-generated
 # This file contains the configuration settings for Elasticsearch 8.
 # For more information, see https://www.elastic.co/guide/en/elasticsearch/reference/current/settings.html
 
@@ -8,7 +7,8 @@ cluster.name: "docker-cluster"
 # https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html#network.host
 network.host: 0.0.0.0
 
-# Security settings
+# Disable security features
+# https://www.elastic.co/guide/en/elasticsearch/reference/current/security-settings.html#general-security-settings
 xpack.security.enabled: false
 xpack.security.autoconfiguration.enabled: false
 xpack.security.enrollment.enabled: false

--- a/.ddev/elasticsearch/elasticsearch-setup.sh
+++ b/.ddev/elasticsearch/elasticsearch-setup.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Exit if no plugins specified
+[ -z "$ELASTICSEARCH_PLUGINS" ] && echo "No plugins specified in ELASTICSEARCH_PLUGINS" && exit 0
+
+echo "Installing Elasticsearch plugins: $ELASTICSEARCH_PLUGINS"
+needs_restart=false
+
+# Process each plugin
+for plugin in $ELASTICSEARCH_PLUGINS; do
+    # Skip if already installed
+    if bin/elasticsearch-plugin list | grep -q "$plugin"; then
+        echo "✓ Plugin $plugin already installed"
+        continue
+    fi
+
+    # Install plugin
+    echo "Installing $plugin plugin..."
+    bin/elasticsearch-plugin install "$plugin" && \
+    chown -R elasticsearch:root "/usr/share/elasticsearch/plugins/$plugin" && \
+    chmod -R 755 "/usr/share/elasticsearch/plugins/$plugin" && \
+    echo "✓ Plugin $plugin installed successfully" && \
+    needs_restart=true
+done
+
+# Signal for restart if needed
+[ "$needs_restart" = true ] && echo "New plugins were installed. Elasticsearch needs to be restarted." && touch /tmp/elasticsearch_needs_restart
+
+exit 0

--- a/.lando.yml
+++ b/.lando.yml
@@ -125,7 +125,7 @@ services:
   #       - esdata:/usr/share/elasticsearch/data
   #   # Install ES plugins.
   #   build_as_root:
-  #     - elasticsearch-plugin install analysis-icu analysis-ukrainian
+  #     - elasticsearch-plugin install analysis-icu
   #   volumes:
   #     esdata:
   #       driver: local

--- a/README.md
+++ b/README.md
@@ -126,33 +126,33 @@ For a complete list of all available services, URLs, and ports, use:
 
 #### DDEV Elasticsearch configuration
 
-This project includes Elasticsearch with the `analysis-icu` plugin for Unicode/multilingual text processing support.
+This project includes Elasticsearch service for robust full-text search capabilities. It's automatically set up during DDEV initialization.
 
-**Configuration and customization:**
+##### Plugins configuration
 
-Plugins are defined in `.ddev/docker-compose.elasticsearch8.yaml` as environment variables. You can install multiple plugins by adding them as space-separated values:
+- Pre-configured with `analysis-icu` for Unicode/multilingual text processing
+- Additional plugins can be defined in `.ddev/docker-compose.elasticsearch8.yaml`
 
 ```yaml
 services:
   elasticsearch:
     environment:
-      - ELASTICSEARCH_PLUGINS=analysis-icu analysis-ukrainian
+      - ELASTICSEARCH_PLUGINS=analysis-icu  # Space-separated plugin list
 ```
 
-The installation process:
-1. Plugin names are defined as space-separated values
-2. A post-start hook installs missing plugins and sets permissions
-3. Elasticsearch restarts automatically if needed
-
-**Useful commands:**
+##### Useful commands
 
 ```bash
+# Check Elasticsearch status
+ddev exec -s elasticsearch "curl -s localhost:9200"
+
 # List installed plugins
 ddev exec -s elasticsearch "bin/elasticsearch-plugin list"
-
-# View detailed plugin information
-ddev exec -s elasticsearch "curl -s localhost:9200/_nodes/plugins?pretty"
 ```
+
+##### Web interface
+
+Elasticvue is included for visualization and management at <http://drupal-project.ddev.site:9005>
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,41 @@ For a complete list of all available services, URLs, and ports, use:
 - `ddev syncdb [environment]` - Sync database from remote environment (requires VPN and `ddev auth ssh`, see `scripts/syncdb.sh` for details)
 
 <details>
+<summary>DDEV Elasticsearch configuration</summary>
+
+#### DDEV Elasticsearch configuration
+
+This project includes Elasticsearch with the `analysis-icu` plugin for Unicode/multilingual text processing support.
+
+**Configuration and customization:**
+
+Plugins are defined in `.ddev/docker-compose.elasticsearch8.yaml` as environment variables. You can install multiple plugins by adding them as space-separated values:
+
+```yaml
+services:
+  elasticsearch:
+    environment:
+      - ELASTICSEARCH_PLUGINS=analysis-icu analysis-ukrainian
+```
+
+The installation process:
+1. Plugin names are defined as space-separated values
+2. A post-start hook installs missing plugins and sets permissions
+3. Elasticsearch restarts automatically if needed
+
+**Useful commands:**
+
+```bash
+# List installed plugins
+ddev exec -s elasticsearch "bin/elasticsearch-plugin list"
+
+# View detailed plugin information
+ddev exec -s elasticsearch "curl -s localhost:9200/_nodes/plugins?pretty"
+```
+
+</details>
+
+<details>
 <summary>Lando environment</summary>
 
 ### Lando environment

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -105,16 +105,6 @@ switch ($env) {
     $settings['cache']['bins']['dynamic_page_cache'] = 'cache.backend.null';
     $settings['cache']['bins']['page'] = 'cache.backend.null';
     $settings['extension_discovery_scan_tests'] = FALSE;
-
-    // Override drupal/symfony_mailer default config to use Mailpit.
-    if ($env === 'ddev') {
-      $config['symfony_mailer.settings']['default_transport'] = 'sendmail';
-      $config['symfony_mailer.mailer_transport.sendmail']['plugin'] = 'smtp';
-      $config['symfony_mailer.mailer_transport.sendmail']['configuration']['user'] = '';
-      $config['symfony_mailer.mailer_transport.sendmail']['configuration']['pass'] = '';
-      $config['symfony_mailer.mailer_transport.sendmail']['configuration']['host'] = 'localhost';
-      $config['symfony_mailer.mailer_transport.sendmail']['configuration']['port'] = '1025';
-    }
     break;
 
   default:


### PR DESCRIPTION
## Ticket QAG-65

## Changes

- 6c3581c & dbd1d1e QAG-65: fix: Fix DDEV Elasticsearch plugin configuration and installation
- 01ac70a QAG-65: build: Switch to npm ci for consistent package installs
- 36134d7 QAG-65: fix: Correct YAML anchor definition in CircleCI config
- 1931e7d QAG-65: build: Remove Ukrainian language analysis plugin from local environments
- 2865acc QAG-65: build: Add npm install to DDEV post-start hooks
- be40af7 QAG-65: fix: Fix mailpit configuration for DDEV environment

## Testing

Enviroment: local DDEV

Instructions:

### Fix mailpit configuration for DDEV environment

- rebuild the DDEV after applying the changes
- perform `ddev mailpit`
- send an email and check if the local mailpit has caught it

### Fix DDEV Elasticsearch plugin configuration and installation

- try to follow `DDEV Elasticsearch configuration` section for DDEV ES configuration
- verify that ES plugins defined in `.ddev/docker-compose.elasticsearch8.yaml` are enabled after `ddev start` or `ddev restart`