### PR TITLE
SLT-1193: Update Silta configuration to use mailpit instead of mailhog

### DIFF
--- a/silta/silta-prod.yml
+++ b/silta/silta-prod.yml
@@ -53,8 +53,8 @@ nginx:
 # basicauth:
 #   enabled: false
 
-# Disable MailHog in production.
-mailhog:
+# Disable Mailpit in production.
+mailpit:
   enabled: false
 
 # MariaDB configuration.

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -17,8 +17,8 @@ referenceData:
   # Configure reference data source for new environments.
   referenceEnvironment: 'main'
 
-# Enable MailHog in non-production environments.
-mailhog:
+# Enable Mailpit in non-production environments.
+mailpit:
   enabled: true
 
 # MariaDB configuration.


### PR DESCRIPTION
## Ticket SLT-1193

## Changes

- Update Silta configuration to use mailpit instead of mailhog as last is deprecated and will be removed from Drupal chart in future

## Testing

Enviroment: https://feature-slt-1193-mail.drupal-project.dev.wdr.io

Instructions:
Test mail functionality, i.e.:
1. Create a new account at https://feature-slt-1193-mail.drupal-project.dev.wdr.io/user/register
2. Go to https://feature-slt-1193-mail.drupal-project.dev.wdr.io/mailpit/, see that user registrations email messages are there
