### PR TITLE
Replace mailhog with mailpit

### DIFF
--- a/silta/silta-prod.yml
+++ b/silta/silta-prod.yml
@@ -54,7 +54,7 @@ nginx:
 #   enabled: false
 
 # Disable MailHog in production.
-mailhog:
+mailpit:
   enabled: false
 
 # MariaDB configuration.

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -18,7 +18,7 @@ referenceData:
   referenceEnvironment: 'main'
 
 # Enable MailHog in non-production environments.
-mailhog:
+mailpit:
   enabled: true
 
 # MariaDB configuration.


### PR DESCRIPTION
This PR updates project's Silta configuration to use mailpit instead of mailhog as last is deprecated and will be removed from Silta's Drupal chart in future.

Without this change helm chart installation thus deployments will start to fail with schema validation errors once mailhog is removed from Silta.

Note that:
  - old mailhog URL /mailhog is still working but redirected to /mailpit (i.e., if you have testing instructions containing old URLs)
  - if you have overridden the default mailhog configuration, please ensure that it's still compliant: https://github.com/wunderio/charts/blob/42f4be6a32b8ee2e662b38144fa608eb3dd4b989/drupal/values.yaml#L753