### PR TITLE
Replace mailhog with mailpit

### DIFF
--- a/silta/silta-prod.yml
+++ b/silta/silta-prod.yml
@@ -53,8 +53,8 @@ nginx:
 # basicauth:
 #   enabled: false
 
-# Disable MailHog in production.
-mailhog:
+# Disable Mailpit in production.
+mailpit:
   enabled: false
 
 # MariaDB configuration.

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -17,8 +17,8 @@ referenceData:
   # Configure reference data source for new environments.
   referenceEnvironment: 'main'
 
-# Enable MailHog in non-production environments.
-mailhog:
+# Enable Mailpit in non-production environments.
+mailpit:
   enabled: true
 
 # MariaDB configuration.


### PR DESCRIPTION
This PR updates Silta configuration to use mailpit instead of mailhog as last is deprecated and will be removed from Silta's Drupal and Frontend charts in near future, refer to the [official Silta documentation](https://wunderio.github.io/silta/docs/silta-examples#sending-e-mail)

Note that:
  - legacy  URL is still available but will be redirected to /mailpit (i.e., if you have testing instructions containing old URLs, no need to update them manually after this change)
  - if you have overridden the default mailhog configuration, please ensure that it's still compliant: https://github.com/wunderio/charts/blob/42f4be6a32b8ee2e662b38144fa608eb3dd4b989/drupal/values.yaml#L753
  
**Without this change helm chart installation thus deployments will start to fail with schema validation errors once mailhog is completely removed from Silta.**
**_In case of any questions, please contact @k4lv15_**