### PR TITLE
Replace mailhog with mailpit

### DIFF
--- a/silta/silta-prod.yml
+++ b/silta/silta-prod.yml
@@ -54,7 +54,7 @@ nginx:
 #   enabled: false
 
 # Disable MailHog in production.
-mailhog:
+mailpit:
   enabled: false
 
 # MariaDB configuration.

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -18,7 +18,7 @@ referenceData:
   referenceEnvironment: 'main'
 
 # Enable MailHog in non-production environments.
-mailhog:
+mailpit:
   enabled: true
 
 # MariaDB configuration.


### PR DESCRIPTION
This PR updates Silta configuration to use mailpit instead of mailhog as last is deprecated and will be removed from Silta's Drupal and Frontend charts in near future, refer to the [official Silta documentation](https://wunderio.github.io/silta/docs/silta-examples#sending-e-mail)

Note that:
- legacy  URL is still available but will be redirected to  (f.e., if you have testing instructions containing old URLs, no need to update them manually after this change)
- if you have overridden the default mailhog configuration, please ensure that it's still compliant with mailpit: https://github.com/wunderio/charts/blob/42f4be6a32b8ee2e662b38144fa608eb3dd4b989/drupal/values.yaml#L753
- if your Silta config contains comments mentioning mailhog i.e., , those need to be adjusted manually (if any)

**Without this change Helm chart installations thus deployments will start to fail with schema validation errors once mailhog is completely removed from Silta.** In case of any questions, please contact @k4lv15

This pull request was created with https://github.com/wunderio/internal-mass-updater