### PR TITLE
Update .dockerignore files

### DIFF
--- a/silta/php.Dockerfile.dockerignore
+++ b/silta/php.Dockerfile.dockerignore
@@ -16,7 +16,5 @@ vendor/**/Tests
 web/sites/**/files
 web/.dockerignore
 Dockerfile
-silta/*.Dockerfile
-silta/*.Dockerfile.dockerignore
 composer.lock
 silta/silta*.yml

--- a/silta/shell.Dockerfile.dockerignore
+++ b/silta/shell.Dockerfile.dockerignore
@@ -16,7 +16,5 @@ vendor/**/Tests
 web/sites/**/files
 web/.dockerignore
 Dockerfile
-silta/*.Dockerfile
-silta/*.Dockerfile.dockerignore
 composer.lock
 silta/silta*.yml


### PR DESCRIPTION
## Changes

This pull request makes a minor update to the .dockerignore files for the Silta project. The change removes the exclusion of Silta Dockerfile and Dockerfile.dockerignore patterns, which may affect which files are ignored during Docker builds.
- Removed the lines ignoring silta/*.Dockerfile and silta/*.Dockerfile.dockerignore from both silta/php.Dockerfile.dockerignore and silta/shell.Dockerfile.dockerignore files.
- Related PR https://github.com/wunderio/drupal-project-k8s/pull/769

## Testing

Instructions:

- Create a and deploy new branch from main
- Edit silta/php.Dockerfile by adding an arbitrary comment
- Deploy the branch again, you'll notice from the CircleCi build job that the php image did not get rebuilt

- Do the same thing but make the new branch from this feature branch
- You'll notice that the php image did get rebuilt
