### PR TITLE
InnoDB undo log truncation

### DIFF
--- a/silta/silta-prod.yml
+++ b/silta/silta-prod.yml
@@ -132,6 +132,9 @@ mariadb:
       performance_schema=1
       innodb_write_io_threads=16
       innodb_use_native_aio=0
+      # Undo Log Truncation
+      innodb_undo_log_truncate=ON
+      innodb_max_undo_log_size=1G
       [client]
       port=3306
       socket=/opt/bitnami/mariadb/tmp/mysql.sock

--- a/silta/silta.yml
+++ b/silta/silta.yml
@@ -73,6 +73,9 @@ mariadb:
       performance_schema=1
       innodb_write_io_threads=16
       innodb_use_native_aio=0
+      # Undo Log Truncation
+      innodb_undo_log_truncate=ON
+      innodb_max_undo_log_size=1G
       [client]
       port=3306
       socket=/opt/bitnami/mariadb/tmp/mysql.sock


### PR DESCRIPTION
Enables InnoDB undo log truncation. Having this disabled (default value) for mariadb 11.x will fill up available disk space.

https://mariadb.com/docs/server/server-usage/storage-engines/innodb/mariadb-enterprise-server-innodb-operations/configure-the-innodb-undo-log