### PR TITLE
WNDR-481: Upgrade PHP to 8.4, Node to 24, MariaDB to 11.4, ddev-agents to 1.2.2 and ddev-wunderio-drupal to 0.7.1

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -1,0 +1,238 @@
+# Local Development MCP
+
+An MCP server that gives AI agents tools to run commands in DDEV containers via SSH. Tools are defined in YAML configuration files.
+
+## Architecture
+
+- **Execution Method**: SSH (passwordless key-based authentication)
+- **SSH Keys**: Ephemeral Ed25519 keys, generated fresh each `ddev start` and distributed via `docker exec`
+- **SSH User**: Automatically detected from web container's `/var/www/html` ownership, configured via SSH client `User` directive
+- **No Docker Socket**: Fully isolated from host Docker daemon
+- **No Persistent State**: No `.runtime.env` or stored keys — everything is set up by the `set-up` hook
+
+## How to Use
+
+1. **Installation:**
+
+   ```bash
+   cd /path/to/ddev-project
+   ddev get wunderio/ddev-agents
+   ddev restart  # Builds container and sets up SSH automatically
+   ```
+
+2. **First Launch:**
+   - Open VS Code in the devcontainer
+   - The wdrmcp MCP server config is at `.vscode/mcp.json`
+   - Note: Due to VS Code bug, search `@mcp` in extension gallery to enable the MCP registry
+   - Open Command Palette: `MCP Servers: List`, find wdrmcp and click Start
+
+3. **Using Tools:**
+   - Open VS Code Copilot chat
+   - Use tools like `drush`, `composer_install`, `logs_nginx_access`, etc.
+   - All tools connect via SSH automatically
+  
+4. **Updating:**
+   Restart of the wdrcmp server is needed to refresh the available tools. For example when:
+   - Adding .env file
+   - Changing the tool configs
+   - Adding a new MCP tool through Drupal MCP
+
+## How SSH Works
+
+SSH keys are **ephemeral** — generated fresh on every `ddev start`:
+
+1. The `set-up` hook (runs post-start on host) generates an Ed25519 keypair
+2. Public key is placed in the web container via `docker exec`
+3. Private key + SSH client config are placed in the agents container via `docker exec`
+4. The SSH client config includes a `User` directive with the detected DDEV user
+5. Keys exist only in container memory — never written to disk on the host
+
+Tool configs use `ssh_target: "web"` — the SSH client config handles which user to connect as.
+
+## Files
+
+- `tools-config/` – YAML tool definitions
+- `mcp.json` – MCP server configuration (copied to `.vscode/mcp.json` by set-up hook)
+
+## Adding a Tool
+
+Create a file in `tools-config/my_tool.yml`:
+
+```yaml
+tools:
+  - name: my_tool
+    type: command
+    enabled: true
+    description: "What this tool does"
+    command_template: "my_command {command} {args}"
+    ssh_target: "web"
+    working_dir: "/var/www/html"
+    default_args:
+      args: []
+    input_schema:
+      type: object
+      properties:
+        command:
+          type: string
+          description: "Command to run"
+        args:
+          type: array
+          items:
+            type: string
+          description: "Flags and options, each as a separate array element"
+      required:
+        - command
+```
+
+### Parameter types
+
+- **`string`** — for single values (commands, package names, file paths).
+- **`array`** with `items: { type: string }` — for flags/options. Each element is individually shell-escaped, so multi-flag use is safe: `["--format=json", "--fields=name,status"]`.
+- **`integer`** — for numeric values (line counts, limits).
+
+String parameters are shell-escaped as a single token. Array parameters have each element escaped individually and joined with spaces. Empty strings and empty arrays produce no output in the rendered command.
+
+## Project `.env` Credentials
+
+If any MCP tool config needs credentials (e.g., Drupal MCP proxy), define them in `.env` inside the `tools-config` directory.
+
+Example credentials file (`.agents/tools-config/.env`):
+
+```dotenv
+DRUPAL_MCP_USER=admin
+DRUPAL_MCP_PASS=admin
+```
+
+This file is preserved across addon reinstalls (non-destructive merge).
+
+## Available Tool Types
+
+- `command` – Run shell commands with parameter substitution
+- `check` – Run checks and tests with parameter substitution
+- `mcp_server` – Proxy to additional MCP servers
+
+### Command Tool Type
+
+Command tools execute shell commands in DDEV containers with parameter substitution.
+
+Example:
+
+```yaml
+tools:
+  - name: my_command_tool
+    type: command
+    enabled: true
+    description: "Execute a custom command"
+    command_template: "my_command {name} {args}"
+    ssh_target: "web"
+    working_dir: "/var/www/html"
+    default_args:
+      args: []
+
+    input_schema:
+      type: object
+      properties:
+        name:
+          type: string
+          description: "Name argument"
+        args:
+          type: array
+          items:
+            type: string
+          description: "Flags and options as separate array elements"
+      required:
+        - name
+```
+
+### Check Tool Type
+
+Check tools execute shell commands like the Command tools (above), but provide
+proper feedback to agents when the checks or tests being run use non-zero
+exit codes to signal that the checks/tests did not pass.
+
+Example:
+
+```yaml
+tools:
+  - name: my_tests_tool
+    type: check
+    enabled: true
+    description: "Run my custom tests"
+    command_template: "my_custom_tests {name} {args}"
+    ssh_target: "web"
+    working_dir: "/var/www/html"
+    # Set to true if you need to bootstrap Drupal (for e.g. drush).
+    use_env_vars_in_remote: false
+    # Exit codes to interpret as the command succeeding, but the checks failing.
+    success_exit_codes: [1, 2]
+    default_args:
+      args: []
+
+    input_schema:
+      type: object
+      properties:
+        name:
+          type: string
+          description: "Name argument"
+        args:
+          type: array
+          items:
+            type: string
+          description: "Flags and options as separate array elements"
+      required:
+        - name
+```
+
+### MCP Server Tool Type
+
+MCP Server tools proxy requests to other MCP servers via HTTP. Both plain JSON-RPC HTTP endpoints and Streamable HTTP MCP endpoints are supported.
+
+For Streamable HTTP MCP endpoints, the proxy uses the MCP SDK Client which handles the protocol handshake, session management, and reconnection automatically. If the remote server does not support the MCP protocol, the proxy falls back to plain JSON-RPC.
+
+**Dynamic Tool Discovery:** When `expose_remote_tools: true` is set, the proxy will query the remote MCP server for all its available tools and expose them as if they were local tools. This allows seamless integration with external MCP servers.
+
+Example (single proxy tool):
+
+```yaml
+tools:
+  - name: my_mcp_tool
+    type: mcp_server
+    enabled: true
+    description: "Proxy to another MCP server"
+    server_url: "http://localhost:8080/endpoint"
+    forward_args: true       # Optional: forward arguments (default: true)
+    timeout: 30              # Optional: timeout in seconds (default: 30)
+    auth_username: "${MCP_USER}"     # Optional: basic auth username
+    auth_password: "${MCP_PASS}"     # Optional: basic auth password
+    input_schema:
+      type: object
+      properties:
+        query:
+          type: string
+      required:
+        - query
+```
+
+Example (dynamic tool exposure):
+
+```yaml
+tools:
+  - name: drupal_mcp
+    type: mcp_server
+    enabled: true
+    description: "Proxy to Drupal MCP server"
+    server_url: "https://drupal-project.ddev.site/mcp/post"
+    auth_username: "${DRUPAL_MCP_USER}"
+    auth_password: "${DRUPAL_MCP_PASS}"
+    expose_remote_tools: true    # Dynamically fetch and expose remote tools
+    tool_prefix: "drupal_"       # Optional: prefix remote tool names
+    timeout: 30
+```
+
+## Logging
+
+View MCP server logs:
+
+```bash
+tail -f /tmp/wdrmcp.log
+```

--- a/.agents/tools-config/composer.yml
+++ b/.agents/tools-config/composer.yml
@@ -1,0 +1,127 @@
+# Composer PHP Dependency Manager Configuration
+# Defines available composer commands
+
+tools:
+  - name: composer_install
+    enabled: true
+    description: |
+      Install dependencies from composer.lock file.
+
+      Always run in the Drupal project directory (/var/www/html).
+      Installs packages with versions locked in composer.lock.
+
+    type: command
+    command_template: "composer install {args}"
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+    default_args:
+      args: ["--no-interaction"]
+
+    input_schema:
+      type: object
+      properties:
+        args:
+          type: array
+          items:
+            type: string
+          description: >
+            Each flag or option as a separate array element.
+            The default ["--no-interaction"] is always included unless overridden.
+            Examples: ["--no-dev"], ["--no-dev", "--optimize-autoloader"].
+
+  - name: composer_update
+    enabled: true
+    description: |
+      Update dependencies to latest versions.
+
+      Always run in the Drupal project directory (/var/www/html).
+      Updates packages according to version constraints in composer.json.
+
+    type: command
+    command_template: "composer update {package} {args}"
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+    default_args:
+      package: ""
+      args: ["--no-interaction"]
+
+    input_schema:
+      type: object
+      properties:
+        package:
+          type: string
+          description: >
+            Package name to update (e.g., "drupal/pathauto").
+            Omit or leave empty to update all packages.
+        args:
+          type: array
+          items:
+            type: string
+          description: >
+            Each flag or option as a separate array element.
+            Examples: ["--with-dependencies"], ["--no-dev", "--prefer-dist"].
+
+  - name: composer_require
+    enabled: true
+    description: |
+      Add one or more dependencies to composer.json.
+
+      Always run in the Drupal project directory (/var/www/html).
+      Adds packages and updates composer.lock.
+
+      Supports multiple packages in a single call — prefer this over separate
+      calls when installing related packages together:
+        {"packages": ["drupal/pathauto", "drupal/token:^1.0"]}
+        {"packages": ["drupal/mcp_server", "drupal/tool"], "args": ["--ignore-platform-req=ext-gd"]}
+
+      Single package still works:
+        {"packages": ["drupal/pathauto"]}
+
+      Troubleshooting installation failures:
+
+      1. **PHP Version Incompatibility** - Package may require different PHP version
+         - Check PHP version: Use drush_php_eval "echo PHP_VERSION;"
+         - Check composer.json: Look for "platform" sections with PHP constraints
+         - Try: args: ["--ignore-platform-req=php-ext-*"]
+
+      2. **Stability Constraints** - Package below minimum-stability threshold
+         - Try: packages: ["drupal/package:@dev"] (or @beta, @alpha)
+         - Or update composer.json "minimum-stability" to "dev"
+
+      3. **Memory Errors** - Large installation can exceed PHP memory limit
+         - Try: Use COMPOSER_MEMORY_LIMIT=-1 environment variable
+
+      4. **Dependency Conflicts** - New package conflicts with existing ones
+         - Try: args: ["--with-all-dependencies"]
+         - This updates related packages to compatible versions
+
+    type: command
+    command_template: "composer require {packages} {args}"
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+    default_args:
+      args: ["--no-interaction"]
+
+    input_schema:
+      type: object
+      properties:
+        packages:
+          type: array
+          items:
+            type: string
+          description: >
+            One or more package names to require.
+            Examples: ["drupal/pathauto"], ["drupal/mcp_server", "drupal/tool:^1.0"].
+            Each element is shell-escaped and joined with spaces in the command.
+        args:
+          type: array
+          items:
+            type: string
+          description: >
+            Each flag or option as a separate array element.
+            Examples: ["--with-all-dependencies"], ["--no-dev", "--prefer-dist"].
+      required:
+        - packages

--- a/.agents/tools-config/drupal.yml
+++ b/.agents/tools-config/drupal.yml
@@ -1,0 +1,74 @@
+# Drupal MCP Server Proxy Configuration
+# Proxies to a Drupal-specific MCP server
+#
+# == SETUP INSTRUCTIONS (run once per project) ==
+#
+# 1. Install and enable the module:
+#      composer_require: drupal/mcp
+#      drush pm:enable mcp -y
+#      drush_cr
+#
+# 2. Enable basic auth:
+#      drush config:set mcp.settings enable_auth true -y
+#      drush config:set mcp.settings auth_settings.enable_basic_auth true -y
+#
+# 3. Verify — expect a JSON-RPC response containing "protocolVersion":
+#      drush_php_eval:
+#        $req = \Symfony\Component\HttpFoundation\Request::create('/mcp/post','POST',[],[],[],
+#          ['HTTP_AUTHORIZATION'=>'Basic '.base64_encode('admin:admin'),'CONTENT_TYPE'=>'application/json'],
+#          json_encode(['jsonrpc'=>'2.0','method'=>'initialize','params'=>['protocolVersion'=>'2024-11-05','capabilities'=>[],'clientInfo'=>['name'=>'test','version'=>'1.0']],'id'=>1]));
+#        echo \Drupal::classResolver(\Drupal\mcp\Controller\McpController::class)->post($req)->getContent();
+#
+# 4. Ask the user for the Drupal admin username and password, then create
+#    .agents/tools-config/.env:
+#      DRUPAL_MCP_USER=<username>
+#      DRUPAL_MCP_PASS=<password>
+#
+# NOTE: Use http://web/mcp/post (internal container URL — bypasses Varnish).
+#       The tool config below already references this URL and the env vars above.
+
+tools:
+  - name: drupal
+    enabled: true
+    type: mcp_server
+    description: |
+      Drupal MCP server proxy for accessing tools provided by the Drupal site.
+
+      This proxies requests to the Drupal site's /mcp/post endpoint to discover
+      and call available tools. Discovered tools are prefixed with "drupal_"
+      (e.g., drupal_general_info).
+
+      Usage:
+      - Use discovered tools directly (e.g., drupal_general_info, drupal_entity_info)
+      - Each discovered tool is automatically prefixed
+
+    # Drupal MCP server endpoint - uses internal DDEV network address
+    server_url: "http://web/mcp/post"
+
+    # Basic authentication (if required by Drupal module)
+    auth_username: "${DRUPAL_MCP_USER}"
+    auth_password: "${DRUPAL_MCP_PASS}"
+
+    # Dynamically expose all tools from the remote MCP server
+    # Tools are automatically prefixed with the tool name: drupal_<tool_name>
+    expose_remote_tools: true
+
+    # Initialization timeout for fetching remote tools (seconds)
+    # Drupal MCP server can be slow, so allow enough time during startup
+    init_timeout: 60
+
+    # Request timeout in seconds (for runtime tool execution)
+    timeout: 60
+
+    # Input schema for JSON-RPC method calls
+    input_schema:
+      type: object
+      properties:
+        method:
+          type: string
+          description: "JSON-RPC method name (e.g., 'tools/list', 'tools/call')"
+        params:
+          type: object
+          description: "Method parameters (varies by method)"
+      required:
+        - method

--- a/.agents/tools-config/drush.yml
+++ b/.agents/tools-config/drush.yml
@@ -1,0 +1,299 @@
+# Drush CLI Tool Configuration
+# Drupal site management via command-line
+
+tools:
+  - name: drush
+    enabled: true
+    description: |
+      Execute Drush commands for Drupal site management.
+
+      Best practice: Always check site status before operations.
+
+      USAGE CONTRACT:
+      - "command" must be a bare Drush command name only (no flags, no operands).
+      - "args" is a string array; each flag or operand is one element.
+      - Operands (module names, entity IDs, etc.) go in args, not command.
+
+      VALID examples:
+      - {"command": "status"}
+      - {"command": "core:status", "args": ["--format=json"]}
+      - {"command": "pm:list", "args": ["--fields=name,status", "--format=json"]}
+      - {"command": "pm:enable", "args": ["mcp", "-y"]}
+      - {"command": "config:get", "args": ["system.site"]}
+
+      INVALID examples (will fail):
+      - {"command": "status --format=json"} — flags must go in args
+      - {"command": "en mcp"} — operands must go in args
+      - {"args": "--format=json"} — args must be an array, not a string
+
+      BLOCKED commands (use dedicated tools instead):
+      - cr / cache-rebuild → use "drush_cr" tool
+      - sql-drop → use "drush_sql_drop" tool
+      - site-install → use "drush_site_install" tool
+      - sql-sync → not permitted
+
+      NEVER use --db-url. Drush auto-configures the database connection from
+      Drupal's settings.php via environment variables. Adding --db-url bypasses
+      this and causes SSL/TLS errors.
+
+      For running PHP code, use the "drush_php_eval" tool instead of drush
+      eval/php-eval (which have escaping and parsing issues).
+
+    type: command
+    command_template: "vendor/bin/drush {command} {args}"
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+
+    default_args:
+      args: []
+
+    # Blocked commands with suggested alternatives
+    disallowed_commands:
+      - pattern: sql-sync
+      - pattern: site-install
+        suggested_tool: drush_site_install
+      - pattern: sql-drop
+        suggested_tool: drush_sql_drop
+      - pattern: cr
+        suggested_tool: drush_cr
+      - pattern: cache-rebuild
+        suggested_tool: drush_cr
+
+    # Validate arguments
+    validation_rules:
+      - field: command
+        pattern: "\\s"
+        message: >
+          Invalid command: must be a bare Drush command name with no spaces.
+          Put flags and operands in the args array instead.
+          Valid: {"command": "pm:enable", "args": ["mcp", "-y"]}.
+          Invalid: {"command": "en mcp"}.
+      - pattern: "--db-url"
+        message: >
+          --db-url is not permitted. Drush auto-configures the database connection
+          from settings.php. Adding --db-url causes SSL/TLS errors.
+
+    input_schema:
+      type: object
+      properties:
+        command:
+          type: string
+          description: >
+            Drush command name ONLY — no flags, no operands, no spaces.
+            Valid: "status", "core:status", "pm:list", "pm:enable", "config:get".
+            Invalid: "status --format=json", "en mcp".
+        args:
+          type: array
+          items:
+            type: string
+          description: >
+            Each flag, option, or operand as a separate array element.
+            Valid: ["--format=json"], ["mcp", "-y"], ["--fields=name,status", "--format=list"].
+            DO NOT use --db-url.
+      required:
+        - command
+
+  - name: drush_cr
+    enabled: true
+    description: |
+      Clear and rebuild all Drupal caches.
+
+      This is the dedicated command for cache rebuild (drush cr/cache-rebuild).
+      Use this instead of the generic drush command for cache operations.
+
+      This command is fast and safe to run at any time. It's commonly used:
+      - After installing or enabling modules
+      - After configuration changes
+      - After code changes that affect cached data
+      - When debugging issues that may be cache-related
+
+    type: command
+    command_template: "vendor/bin/drush cache:rebuild"
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+
+    input_schema:
+      type: object
+      properties: {}
+
+  - name: drush_sql_drop
+    enabled: true
+    description: |
+      Safely drop the Drupal database using environment-configured connection.
+
+      This is a safe alternative to 'drush sql-drop' that avoids --db-url issues.
+      Database is configured via environment variables, not connection strings.
+
+    type: command
+    command_template: "vendor/bin/drush sql-drop -y --extra=--skip-ssl 2>&1 || true"
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+
+    input_schema:
+      type: object
+      properties: {}
+
+  - name: drush_site_install
+    enabled: true
+    description: |
+      Safely install/reinstall Drupal using environment-configured database.
+
+      This is a safe alternative that avoids --db-url issues. Database must be
+      pre-dropped before installation (use drush_sql_drop first).
+
+      Parameters control admin account and installation profile.
+
+    type: command
+    command_template: "vendor/bin/drush site-install {profile} -y --account-name={admin_name} --account-pass={admin_pass} --extra=--skip-ssl"
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+
+    default_args:
+      profile: "standard"
+      admin_name: "admin"
+      admin_pass: "admin"
+
+    input_schema:
+      type: object
+      properties:
+        profile:
+          type: string
+          description: Installation profile (default "standard", e.g. "minimal", "standard")
+          default: "standard"
+        admin_name:
+          type: string
+          description: Administrator username (default "admin")
+          default: "admin"
+        admin_pass:
+          type: string
+          description: Administrator password (default "admin")
+          default: "admin"
+
+  - name: logs_watchdog
+    enabled: true
+    description: |
+      Read Drupal watchdog logs from the database.
+
+      Shows application-level logs stored in Drupal's watchdog table (dblog module).
+      Requires drush and dblog module to be enabled.
+      Default: Last 100 entries. Maximum: 1000 entries.
+
+    type: command
+    command_template: "vendor/bin/drush watchdog:show --count={lines}"
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+    default_args:
+      lines: "100"
+
+    input_schema:
+      type: object
+      properties:
+        lines:
+          type: integer
+          description: Number of entries to return (default 100, max 1000)
+
+  - name: drush_php_eval
+    enabled: true
+    description: |
+      Execute PHP code with full Drupal bootstrap context.
+
+      Use this for:
+      - Testing code snippets before implementation
+      - Exploring Drupal APIs and data structures
+      - Debugging application state
+      - Querying entities and configuration
+      - One-off data operations
+
+      DO NOT use for:
+      - Operations available via drush (use drush instead)
+      - Database operations (use drush sql-* or create proper migrations)
+
+      CODE SIZE LIMIT: 16 384 characters max. If your code is longer, use
+      "drush_php_script" instead — write the code to a file and execute it.
+
+      PATH NORMALIZATION: File paths in your code must use /var/www/html/ (the
+      container path), not /workspace/. The devcontainer's /workspace/ is bind-
+      mounted to /var/www/html/ inside the web container where Drush runs.
+
+      The code runs in the context of a bootstrapped Drupal site with all APIs available.
+
+      Examples:
+      - Get node count: echo \Drupal::entityQuery('node')->count()->execute();
+      - List content types: print_r(array_keys(\Drupal::entityTypeManager()->getStorage('node_type')->loadMultiple()));
+      - Check module status: echo \Drupal::moduleHandler()->moduleExists('views') ? 'enabled' : 'disabled';
+
+    type: command
+    command_template: "vendor/bin/drush php:eval {code}"
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+    max_arg_length: 16384
+
+    input_schema:
+      type: object
+      properties:
+        code:
+          type: string
+          description: |
+            PHP code to execute (without <?php tags).
+            Use single quotes in the code, as double quotes may cause issues.
+            Max 16 384 characters — use drush_php_script for longer code.
+      required:
+        - code
+
+  - name: drush_php_script
+    enabled: true
+    description: |
+      Execute a PHP script file with full Drupal bootstrap context.
+
+      Use this instead of drush_php_eval when:
+      - Code exceeds the 16 384-character eval limit
+      - You need multi-file or complex logic
+      - You want to iterate on a script without re-sending the full code
+
+      PATH NORMALIZATION: The script must exist inside /var/www/html/ on the
+      web container. The devcontainer's /workspace/ is bind-mounted to
+      /var/www/html/, so a file you create at /workspace/scripts/foo.php
+      should be referenced as scripts/foo.php (relative) or
+      /var/www/html/scripts/foo.php (absolute).
+
+      EXTRA ARGUMENTS: Any values in "args" are available inside the script via
+      the $extra variable (a string of all arguments joined by spaces). You can
+      also access them via drush_get_arguments() or the $extra convention
+      documented in `drush topic docs:script`.
+
+      Examples:
+      - Run a script: {"script_path": "scripts/migrate.php"}
+      - With args:    {"script_path": "scripts/fix.php", "args": ["--force", "node"]}
+
+    type: command
+    command_template: "vendor/bin/drush php:script {script_path} {args}"
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+
+    default_args:
+      args: []
+
+    input_schema:
+      type: object
+      properties:
+        script_path:
+          type: string
+          description: |
+            Path to the PHP script file (without <?php tags in the file is fine —
+            Drush handles it). Relative paths resolve from /var/www/html/.
+        args:
+          type: array
+          items:
+            type: string
+          description: |
+            Extra arguments passed to the script. Available in the script as
+            the $extra variable. Each element is shell-escaped separately.
+      required:
+        - script_path

--- a/.agents/tools-config/grumphp.yml
+++ b/.agents/tools-config/grumphp.yml
@@ -1,0 +1,142 @@
+# Validation - GrumPHP
+#
+# - PHP compatibility
+# - Check syntax
+# - PHPCS
+# - PHPstan
+# - yaml_lint
+# - json_lint
+
+tools:
+  - name: grumphp_run
+    enabled: true
+    description: |
+      Run all GrumPHP checks on the entire codebase.
+
+    # Note the type of this tool: test runners like grumphp may exit
+    # with a non-zero exit code if the command succeeds but checks/tests fail;
+    # the "check" executor will report the passed/failed status to agents.
+    #
+    # See: success_exit_codes
+    type: check
+    command_template: "./vendor/bin/grumphp run --no-ansi --no-interaction"
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+    timeout: 120 # seconds
+    use_env_vars_in_remote: false
+    # Consider exit code 1 as the command succeeding,
+    # but report it as "checks failed".
+    # Note that the default value is [1].
+    # success_exit_codes: [1]
+    input_schema:
+      type: object
+      properties: {}
+
+  - name: grumphp_check_php_compatibility
+    enabled: true
+    description: |
+      Run PHP compatibility checks on the entire codebase.
+
+    type: check
+    command_template: "./vendor/bin/grumphp run --tasks {tasks} --no-ansi --no-interaction"
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+    timeout: 60 # seconds
+    use_env_vars_in_remote: false
+    default_args:
+      tasks: ["php_compatibility"]
+    input_schema:
+      type: object
+      properties: {}
+
+  - name: grumphp_check_php_syntax
+    enabled: true
+    description: |
+      Run PHP syntax checking on the entire codebase.
+
+    type: check
+    command_template: "./vendor/bin/grumphp run --tasks {tasks} --no-ansi --no-interaction"
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+    timeout: 60 # seconds
+    use_env_vars_in_remote: false
+    default_args:
+      tasks: ["php_check_syntax"]
+    input_schema:
+      type: object
+      properties: {}
+
+  - name: grumphp_check_phpcs
+    enabled: true
+    description: |
+      Run PHPCS checks on the entire codebase.
+
+    type: check
+    command_template: "./vendor/bin/grumphp run --tasks {tasks} --no-ansi --no-interaction"
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+    timeout: 60 # seconds
+    use_env_vars_in_remote: false
+    default_args:
+      tasks: ["phpcs"]
+    input_schema:
+      type: object
+      properties: {}
+
+  - name: grumphp_check_phpstan
+    enabled: true
+    description: |
+      Run PHPStan checks on the entire codebase.
+
+    type: check
+    command_template: "./vendor/bin/grumphp run --tasks {tasks} --no-ansi --no-interaction"
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+    timeout: 60 # seconds
+    use_env_vars_in_remote: false
+    default_args:
+      tasks: ["php_stan"]
+    input_schema:
+      type: object
+      properties: {}
+
+  - name: grumphp_lint_yaml
+    enabled: true
+    description: |
+      Run YAML linting on the entire codebase.
+
+    type: check
+    command_template: "./vendor/bin/grumphp run --tasks {tasks} --no-ansi --no-interaction"
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+    timeout: 60 # seconds
+    use_env_vars_in_remote: false
+    default_args:
+      tasks: ["yaml_lint"]
+    input_schema:
+      type: object
+      properties: {}
+
+  - name: grumphp_lint_json
+    enabled: true
+    description: |
+      Run JSON linting on the entire codebase.
+
+    type: check
+    command_template: "./vendor/bin/grumphp run --tasks {tasks} --no-ansi --no-interaction"
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+    timeout: 60 # seconds
+    use_env_vars_in_remote: false
+    default_args:
+      tasks: ["json_lint"]
+    input_schema:
+      type: object
+      properties: {}

--- a/.agents/tools-config/logs.yml
+++ b/.agents/tools-config/logs.yml
@@ -1,0 +1,70 @@
+# Logs Access Configuration
+# Read server and application logs for debugging
+# Each log type is a separate command for flexibility - logs may reside in different containers
+
+tools:
+  - name: logs_nginx_access
+    enabled: true
+    description: |
+      Read Nginx web server access logs.
+
+      Shows HTTP requests to the web server including method, path, status, response time, etc.
+      Default: Last 100 lines. Maximum: 1000 lines.
+
+    type: command
+    command_template: "tail -n {lines} /var/log/nginx/access.log"
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    default_args:
+      lines: "100"
+
+    input_schema:
+      type: object
+      properties:
+        lines:
+          type: integer
+          description: Number of lines to return (default 100, max 1000)
+
+  - name: logs_nginx_error
+    enabled: true
+    description: |
+      Read Nginx web server error logs.
+
+      Shows errors, warnings, and diagnostics from the Nginx web server.
+      Default: Last 100 lines. Maximum: 1000 lines.
+
+    type: command
+    command_template: "tail -n {lines} /var/log/nginx/error.log"
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    default_args:
+      lines: "100"
+
+    input_schema:
+      type: object
+      properties:
+        lines:
+          type: integer
+          description: Number of lines to return (default 100, max 1000)
+
+  - name: logs_php_fpm
+    enabled: true
+    description: |
+      Read PHP-FPM runtime error logs.
+
+      Shows PHP warnings, notices, errors, and fatal exceptions from the PHP-FPM process.
+      Default: Last 100 lines. Maximum: 1000 lines.
+
+    type: command
+    command_template: 'tail -n {lines} /var/log/php-fpm.log 2>/dev/null || echo "PHP-FPM log not found"'
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    default_args:
+      lines: "100"
+
+    input_schema:
+      type: object
+      properties:
+        lines:
+          type: integer
+          description: Number of lines to return (default 100, max 1000)

--- a/.agents/tools-config/npm.yml
+++ b/.agents/tools-config/npm.yml
@@ -1,0 +1,41 @@
+# npm-related tools
+#
+# NOTE: These are examples and probably need to be adapted to every project.
+
+tools:
+  - name: npm_run_build
+    enabled: true
+    description: |
+      Build the frontend application.
+
+    type: command
+    command_template: "npm run build"
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+    timeout: 10 # seconds
+    use_env_vars_in_remote: false
+    default_args: {}
+    input_schema:
+      type: object
+      properties: {}
+
+  - name: npm_run_test
+    enabled: true
+    description: |
+      Run tests defined in the project's package.json.
+
+    type: check
+    command_template: "npm run test"
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+    timeout: 10 # seconds
+    # Consider both exit codes 1 and 2 as the command succeeding,
+    # but report them as "checks failed".
+    success_exit_codes: [1, 2]
+    use_env_vars_in_remote: false
+    default_args: {}
+    input_schema:
+      type: object
+      properties: {}

--- a/.agents/tools-config/phpunit.yml
+++ b/.agents/tools-config/phpunit.yml
@@ -1,0 +1,92 @@
+# PHPUnit tests.
+
+tools:
+  - name: phpunit_list_all_test_suites
+    enabled: true
+    description: |
+      Lists all available test suites.
+
+    type: command
+    command_template: "./vendor/bin/phpunit --configuration phpunit.xml --list-suites"
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+    input_schema:
+      type: object
+      properties: {}
+
+  - name: phpunit_list_all_test_files
+    enabled: true
+    description: |
+      Lists all available test files.
+
+    type: command
+    command_template: "./vendor/bin/phpunit --configuration phpunit.xml --list-test-files"
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+    input_schema:
+      type: object
+      properties: {}
+
+  - name: phpunit_run_all_tests
+    enabled: true
+    description: |
+      Run all tests using PHPUnit.
+
+    type: check
+    command_template: "./vendor/bin/phpunit --configuration phpunit.xml"
+    success_exit_codes: [1, 2]
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+    input_schema:
+      type: object
+      properties: {}
+
+  - name: phpunit_run_test_suites
+    enabled: true
+    description: |
+      Run specific test suites using PHPUnit.
+      Use phpunit_list_all_test_suites to discover the names of test suites.
+
+    type: check
+    command_template: "./vendor/bin/phpunit --configuration phpunit.xml --no-progress --testsuite {names}"
+    success_exit_codes: [1, 2]
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+
+    input_schema:
+      type: object
+      properties:
+        names:
+          type: string
+          description: >
+            Name of the test suite to run, or a comma-separated list of test suite names.
+      required:
+        - names
+
+  - name: phpunit_run_test_files
+    enabled: true
+    description: |
+      Run specific unit test files using PHPUnit.
+
+    type: check
+    command_template: "./vendor/bin/phpunit --configuration phpunit.xml --no-progress {files}"
+    success_exit_codes: [1, 2]
+    ssh_target: "web"
+    ssh_user: "${DDEV_SSH_USER}"
+    working_dir: "/var/www/html"
+
+    input_schema:
+      type: object
+      properties:
+        files:
+          type: array
+          items:
+            type: string
+          description: >
+            Paths to unit test files to run.
+      required:
+        - files

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
 executors:
   silta:
     docker:
-      - image: wunderio/silta-cicd:circleci-php8.3-node22-composer2-v1
+      - image: wunderio/silta-cicd:circleci-php8.4-node24-composer2-v1
 
 # Define shared branch filters as reusable anchors.
 branch-filters:

--- a/.cursor/rules/common.mdc
+++ b/.cursor/rules/common.mdc
@@ -103,7 +103,7 @@ When creating commit messages, always analyze the actual changes using `git diff
 ## Development Environment
 
 ### Code Standards
-- PHP version: 8.3+ (as specified in @composer.json)
+- PHP version: 8.4+ (as specified in @composer.json)
 - Follow Drupal coding standards (defined in @phpcs.xml)
 - Follow PHP Static Analysis rules (defined in @phpstan.neon)
 - Use GrumPHP for enforcing code quality standards (@grumphp.yml)

--- a/.ddev/addon-metadata/ddev-agents/manifest.yaml
+++ b/.ddev/addon-metadata/ddev-agents/manifest.yaml
@@ -1,9 +1,17 @@
 name: ddev-agents
 repository: wunderio/ddev-agents
-version: "0.4"
-install_date: "2026-02-02T13:10:15+02:00"
+version: 1.2.2
+install_date: "2026-07-09T18:20:26+03:00"
 project_files:
     - docker-compose.agents.yaml
+    - config.agents.yaml
     - .devcontainer/devcontainer.json
+    - .devcontainer/devcontainer.build.json
+    - commands/host/copilot
+    - commands/host/build-devcontainer
+    - commands/host/set-up
+    - copilot-managed-config.json
+    - .agents
+    - web-build
 global_files: []
 removal_actions: []

--- a/.ddev/addon-metadata/ddev-wunderio-drupal/manifest.yaml
+++ b/.ddev/addon-metadata/ddev-wunderio-drupal/manifest.yaml
@@ -1,11 +1,13 @@
 name: ddev-wunderio-drupal
 repository: wunderio/ddev-wunderio-drupal
-version: 0.6.0
-install_date: "2026-06-01T07:33:05+03:00"
+version: 0.7.1
+install_date: "2026-07-08T14:38:24+03:00"
 project_files:
     - config.wunderio.yaml
     - docker-compose.wunderio.yaml
 global_files:
     - commands/
-    - wunderio/core/
-removal_actions: []
+    - homeadditions/
+removal_actions:
+    - rm -rf "${DDEV_GLOBAL_DIR}/homeadditions/wunderio"
+    - rm -rf "${DDEV_GLOBAL_DIR}/wunderio/core"

--- a/.ddev/commands/host/build-devcontainer
+++ b/.ddev/commands/host/build-devcontainer
@@ -1,0 +1,99 @@
+#!/bin/bash
+#ddev-generated
+
+## Description: Build devcontainer image before DDEV starts
+## Usage: build-devcontainer
+## Example: "ddev build-devcontainer"
+
+set -e
+
+echo "🔨 Building devcontainer image..."
+
+echo "⌛️ Checking for required tools..."
+
+if ! command -v jq &> /dev/null; then
+    echo "❌ jq CLI not found. Please install jq first."
+    exit 1
+fi
+
+if ! command -v npm &> /dev/null; then
+    echo "❌ npm CLI not found. Please install Node.js and npm first."
+    exit 1
+fi
+
+# Check node version for devcontainer CLI compatibility:
+HOST_NODE_VERSION=$(node -v 2>/dev/null || echo "v0.0.0")
+HOST_NODE_VERSION="${HOST_NODE_VERSION#v}"
+echo "📍 Host Node.js version: $HOST_NODE_VERSION"
+REQUIRED_NODE_MAJOR=20
+HOST_NODE_MAJOR=$(echo "$HOST_NODE_VERSION" | cut -d. -f1)
+if [ "$HOST_NODE_MAJOR" -lt "$REQUIRED_NODE_MAJOR" ]; then
+    echo "❌ Node.js version $HOST_NODE_VERSION is not supported. Please install Node.js v${REQUIRED_NODE_MAJOR}.0.0 or higher."
+    exit 1
+fi
+
+echo "✅ All required tools are available."
+
+# Navigate to project root
+PROJECT_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+cd "$PROJECT_ROOT"
+
+# Get DDEV project name
+DDEV_PROJECT=$(ddev describe -j | jq -r '.raw.name' 2>/dev/null || echo "ddev-agents")
+
+echo "🔍 Project: $DDEV_PROJECT"
+echo "🔨 Building image: ddev-${DDEV_PROJECT}-devcontainer:latest"
+
+# Check if devcontainer CLI is available
+if ! command -v devcontainer &> /dev/null; then
+    echo "⚠️  devcontainer CLI not found. Installing..."
+    npm install -g @devcontainers/cli
+fi
+
+# ==============================================================================
+# Resolve version placeholders from .ddev/config.yaml
+# ==============================================================================
+DDEV_CONFIG="$PROJECT_ROOT/.ddev/config.yaml"
+PHP_VERSION=""
+NODE_VERSION=""
+
+if [ -f "$DDEV_CONFIG" ]; then
+    PHP_VERSION=$(grep -E '^\s*php_version:' "$DDEV_CONFIG" | sed -E 's/.*php_version:[[:space:]]*"?([^"]*)"?/\1/' | xargs)
+    NODE_VERSION=$(grep -E '^\s*nodejs_version:' "$DDEV_CONFIG" | sed -E 's/.*nodejs_version:[[:space:]]*"?([^"]*)"?/\1/' | xargs)
+fi
+
+# Defaults if not found
+PHP_VERSION="${PHP_VERSION:-8.3}"
+NODE_VERSION="${NODE_VERSION:-22}"
+
+echo "📍 PHP version: $PHP_VERSION"
+echo "📍 Node.js version: $NODE_VERSION"
+
+# Create a temp copy of build config with resolved placeholders
+BUILD_CONFIG_TEMPLATE="$PROJECT_ROOT/.devcontainer/devcontainer.build.json"
+BUILD_CONFIG=$(mktemp "${TMPDIR:-/tmp}/devcontainer-build-XXXXXX.json")
+sed -e "s|__PHP_VERSION__|${PHP_VERSION}|g" \
+    -e "s|__NODE_VERSION__|${NODE_VERSION}|g" \
+    -e "s|__PROJECT_NAME__|${DDEV_PROJECT}|g" \
+    "$BUILD_CONFIG_TEMPLATE" > "$BUILD_CONFIG"
+
+echo "🚀 Building with devcontainer CLI (features will be installed)..."
+
+# Build using devcontainer CLI - this will install all the features
+devcontainer build \
+    --workspace-folder "$PROJECT_ROOT" \
+    --image-name "ddev-${DDEV_PROJECT}-devcontainer:latest" \
+    --config "$BUILD_CONFIG"
+
+BUILD_EXIT_CODE=$?
+
+# Clean up temp file
+rm -f "$BUILD_CONFIG"
+
+if [ $BUILD_EXIT_CODE -ne 0 ]; then
+    echo "❌ Devcontainer build failed with exit code $BUILD_EXIT_CODE"
+    exit $BUILD_EXIT_CODE
+fi
+
+echo "✅ Devcontainer image built successfully: ddev-${DDEV_PROJECT}-devcontainer:latest"
+echo "   VS Code will attach to this pre-built image via docker-compose"

--- a/.ddev/commands/host/copilot
+++ b/.ddev/commands/host/copilot
@@ -1,0 +1,61 @@
+#!/bin/bash
+#ddev-generated
+
+## Description: Run GitHub Copilot CLI inside the agents container
+## Usage: copilot [args]
+## Example: copilot
+## Example: copilot -p "Explain this code"
+
+# Check if the agents container is running
+if ! docker ps --format '{{.Names}}' | grep -q "ddev-${DDEV_PROJECT}-agents"; then
+    echo "❌ Error: agents container is not running"
+    echo "👉 Run 'ddev start' first"
+    exit 1
+fi
+
+# Get DDEV project name
+if [ -z "$DDEV_PROJECT" ]; then
+    DDEV_PROJECT=$(ddev describe -j 2>/dev/null | jq -r '.raw.name' 2>/dev/null || echo "ddev-agents")
+fi
+
+# Check if the devcontainer image exists
+if ! docker images --format '{{.Repository}}:{{.Tag}}' | grep -q "ddev-${DDEV_PROJECT}-devcontainer:latest"; then
+    echo "❌ Error: devcontainer image not built"
+    echo "👉 Run 'ddev restart' to build the agents devcontainer"
+    exit 1
+fi
+
+# Check if GitHub CLI is installed
+if ! docker exec -it "ddev-${DDEV_PROJECT}-agents" bash -c "command -v gh &> /dev/null"; then
+    echo "❌ Error: GitHub CLI (gh) not found in agents container"
+    echo "👉 Ensure the devcontainer has the 'ghcr.io/devcontainers/features/github-cli' feature"
+    exit 1
+fi
+
+# Check if Copilot CLI extension is installed
+if ! docker exec -it "ddev-${DDEV_PROJECT}-agents" bash -c "gh copilot --version &> /dev/null"; then
+    echo "⚠️  GitHub Copilot CLI extension not found. Installing..."
+    docker exec -it "ddev-${DDEV_PROJECT}-agents" bash -c "gh extension install github/gh-copilot"
+fi
+
+# Check if GH_TOKEN is set in the container
+if ! docker exec -it "ddev-${DDEV_PROJECT}-agents" bash -c '[ -n "$GH_TOKEN" ]'; then
+    echo "❌ Error: GH_TOKEN not found in agents container"
+    echo "👉 Set DDEV_AGENTS_GH_TOKEN on your host (see README for instructions)"
+    exit 1
+fi
+
+# Check if copilot-managed-config.json exists
+if [ ! -f ".ddev/copilot-managed-config.json" ]; then
+    echo "⚠️  Warning: copilot-managed-config.json not found"
+    echo "� Security restrictions may not be enforced"
+fi
+
+# Run Copilot CLI in interactive or headless mode
+if [ "$#" -eq 0 ]; then
+    # Interactive mode (no arguments)
+    docker exec -it "ddev-${DDEV_PROJECT}-agents" bash -c "cd /workspace && exec gh copilot"
+else
+    # Headless mode (pass all arguments)
+    docker exec -it "ddev-${DDEV_PROJECT}-agents" bash -c "cd /workspace && exec gh copilot $(printf '%q ' "$@")"
+fi

--- a/.ddev/commands/host/set-up
+++ b/.ddev/commands/host/set-up
@@ -1,0 +1,310 @@
+#!/bin/bash
+#ddev-generated
+## Description: Set up devcontainer after DDEV starts (makes the agents container a real devcontainer)
+## Usage: set-up
+## Example: "ddev set-up"
+
+set -e
+
+# Resolve project root from this script's location (.ddev/commands/host/)
+PROJECT_ROOT="$(cd "$(dirname "$0")/../../.." && pwd)"
+cd "$PROJECT_ROOT"
+
+PROJECT_LOCALE="en_US.utf8"
+
+# Determine project name
+if [ -z "$DDEV_PROJECT" ]; then
+    DDEV_PROJECT=$(ddev describe -j 2>/dev/null | jq -r '.raw.name' 2>/dev/null || echo "ddev-agents")
+fi
+
+AGENTS_CONTAINER="ddev-${DDEV_PROJECT}-agents"
+WEB_CONTAINER="ddev-${DDEV_PROJECT}-web"
+
+echo "🔍 Project: $DDEV_PROJECT"
+
+# Verify DDEV is running
+if ! docker ps --format '{{.Names}}' | grep -q "^${AGENTS_CONTAINER}$"; then
+    echo "❌ agents container not running. Run 'ddev start' first."
+    exit 1
+fi
+
+CONTAINER_ID=$(docker inspect --format '{{.Id}}' "$AGENTS_CONTAINER")
+echo "✅ Agents container found: ${CONTAINER_ID:0:12}"
+
+# ==============================================================================
+# Resolve version placeholders in devcontainer.json
+# ==============================================================================
+DDEV_CONFIG="$PROJECT_ROOT/.ddev/config.yaml"
+PHP_VERSION=""
+NODE_VERSION=""
+
+if [ -f "$DDEV_CONFIG" ]; then
+    PHP_VERSION=$(grep -E '^\s*php_version:' "$DDEV_CONFIG" | sed -E 's/.*php_version:[[:space:]]*"?([^"]*)"?/\1/' | xargs)
+    NODE_VERSION=$(grep -E '^\s*nodejs_version:' "$DDEV_CONFIG" | sed -E 's/.*nodejs_version:[[:space:]]*"?([^"]*)"?/\1/' | xargs)
+fi
+
+PHP_VERSION="${PHP_VERSION:-8.3}"
+NODE_VERSION="${NODE_VERSION:-22}"
+
+DEVCONTAINER_JSON="$PROJECT_ROOT/.devcontainer/devcontainer.json"
+if [ -f "$DEVCONTAINER_JSON" ] && grep -q "__PHP_VERSION__\|__NODE_VERSION__\|__PROJECT_NAME__" "$DEVCONTAINER_JSON"; then
+    echo "📍 Resolving devcontainer.json: PHP $PHP_VERSION, Node $NODE_VERSION"
+    sed -i.bak \
+        -e "s|__PHP_VERSION__|${PHP_VERSION}|g" \
+        -e "s|__NODE_VERSION__|${NODE_VERSION}|g" \
+        -e "s|__PROJECT_NAME__|${DDEV_PROJECT}|g" \
+        "$DEVCONTAINER_JSON"
+    rm -f "${DEVCONTAINER_JSON}.bak"
+fi
+
+# ==============================================================================
+# Verify host Node.js (needed for devcontainer CLI and npx -y in MCP configs)
+# ==============================================================================
+NODE_MIN=22
+if ! command -v node &>/dev/null; then
+    echo "❌ Node.js is not installed. Version ${NODE_MIN}+ is required."
+    exit 1
+fi
+if ! HOST_NODE_MAJOR=$(node -e 'process.stdout.write(process.versions.node.split(".")[0])' 2>/dev/null); then
+    echo "❌ Failed to determine Node.js version. Version ${NODE_MIN}+ is required."
+    exit 1
+fi
+if ! [[ "$HOST_NODE_MAJOR" =~ ^[0-9]+$ ]]; then
+    echo "❌ Unexpected Node.js version format: $(node --version). Version ${NODE_MIN}+ is required."
+    exit 1
+fi
+if [ "$HOST_NODE_MAJOR" -lt "$NODE_MIN" ]; then
+    echo "❌ Node.js $(node --version) is too old. Version ${NODE_MIN}+ is required."
+    exit 1
+fi
+
+# Ensure devcontainer CLI is available
+if ! command -v devcontainer &>/dev/null; then
+    echo "⚠️  devcontainer CLI not found. Installing..."
+    npm install -g @devcontainers/cli
+fi
+
+echo "🚀 Running devcontainer set-up to apply devcontainer metadata and lifecycle commands..."
+
+# devcontainer set-up re-uses the already-running container by its ID,
+# applies devcontainer metadata labels, and runs postCreate/postAttach hooks.
+devcontainer set-up \
+    --container-id "$CONTAINER_ID"
+
+echo ""
+echo "✅ Devcontainer is ready."
+
+# ==============================================================================
+# SSH key generation and distribution (ephemeral)
+# ==============================================================================
+echo ""
+echo "🔐 Setting up SSH connectivity between agents and web containers..."
+
+# Verify web container is running
+if ! docker ps --format '{{.Names}}' | grep -q "^${WEB_CONTAINER}$"; then
+    echo "⚠️  Web container not running, skipping SSH setup."
+else
+    # Detect DDEV user from the container's configured UID (set by DDEV in docker-compose)
+    CONTAINER_UID=$(docker inspect --format '{{.Config.User}}' "$WEB_CONTAINER" 2>/dev/null | cut -d: -f1)
+    DDEV_USER=$(docker exec "$WEB_CONTAINER" getent passwd "$CONTAINER_UID" 2>/dev/null | cut -d: -f1)
+    if [ -z "$DDEV_USER" ]; then
+        echo "⚠️  Could not detect DDEV user, skipping SSH setup."
+    else
+        echo "📍 Detected DDEV user: $DDEV_USER"
+
+        # Generate ephemeral Ed25519 keypair
+        SSH_TMPDIR=$(mktemp -d "${TMPDIR:-/tmp}/ddev-ssh-XXXXXX")
+        ssh-keygen -t ed25519 -f "$SSH_TMPDIR/id_ed25519" -N "" -q -C "ddev-agents-ephemeral"
+
+        # --- Place public key in web container ---
+        DDEV_USER_HOME=$(docker exec "$WEB_CONTAINER" bash -c "getent passwd $DDEV_USER | cut -d: -f6" 2>/dev/null)
+        if [ -n "$DDEV_USER_HOME" ] && [ "$DDEV_USER_HOME" != "/" ]; then
+            docker exec "$WEB_CONTAINER" bash -c "
+                mkdir -p '$DDEV_USER_HOME/.ssh'
+                chown '$DDEV_USER' '$DDEV_USER_HOME/.ssh'
+                chmod 700 '$DDEV_USER_HOME/.ssh'
+            "
+            cat "$SSH_TMPDIR/id_ed25519.pub" | docker exec -i "$WEB_CONTAINER" bash -c "
+                cat > '$DDEV_USER_HOME/.ssh/authorized_keys'
+                chown '$DDEV_USER' '$DDEV_USER_HOME/.ssh/authorized_keys'
+                chmod 600 '$DDEV_USER_HOME/.ssh/authorized_keys'
+            "
+            echo "✅ Public key placed in web container for user $DDEV_USER"
+        else
+            echo "⚠️  Could not determine home directory for $DDEV_USER"
+        fi
+
+        # --- Place private key and SSH config in agents container ---
+        # Use -u vscode to avoid cap_drop: ALL / chown issues
+        cat "$SSH_TMPDIR/id_ed25519" | docker exec -i -u vscode "$AGENTS_CONTAINER" bash -c '
+            mkdir -p ~/.ssh && chmod 700 ~/.ssh
+            cat > ~/.ssh/id_ed25519 && chmod 600 ~/.ssh/id_ed25519
+        '
+
+        # Write SSH client config (no User directive — tool configs specify ssh_user explicitly)
+        docker exec -i -u vscode "$AGENTS_CONTAINER" bash -c "cat > ~/.ssh/config && chmod 600 ~/.ssh/config" <<SSHCONFIG
+# Auto-generated by ddev set-up — ephemeral, regenerated each ddev start
+# User is specified per-connection by MCP tool configs (ssh_user field)
+Host web db
+    StrictHostKeyChecking no
+    UserKnownHostsFile /dev/null
+    LogLevel ERROR
+    IdentityFile ~/.ssh/id_ed25519
+SSHCONFIG
+        echo "✅ Private key and SSH config placed in agents container"
+
+        # Set DDEV_SSH_USER env var in agents container for MCP tool configs
+        docker exec -i -u vscode "$AGENTS_CONTAINER" bash -c "
+            grep -q 'export DDEV_SSH_USER=' ~/.bashrc 2>/dev/null || echo 'export DDEV_SSH_USER=$DDEV_USER' >> ~/.bashrc
+            grep -q 'export DDEV_SSH_USER=' ~/.zshrc 2>/dev/null || echo 'export DDEV_SSH_USER=$DDEV_USER' >> ~/.zshrc
+        "
+        echo "✅ DDEV_SSH_USER=$DDEV_USER set in agents container shell configs"
+
+        # Set locale in agents container for MCP tool configs
+        docker exec -i -u vscode "$AGENTS_CONTAINER" bash -c "
+            grep -q 'export LANG=' ~/.bashrc 2>/dev/null || echo 'export LANG=$PROJECT_LOCALE' >> ~/.bashrc
+            grep -q 'export LANG=' ~/.zshrc 2>/dev/null || echo 'export LANG=$PROJECT_LOCALE' >> ~/.zshrc
+            grep -q 'export LC_ALL=' ~/.bashrc 2>/dev/null || echo 'export LC_ALL=$PROJECT_LOCALE' >> ~/.bashrc
+            grep -q 'export LC_ALL=' ~/.zshrc 2>/dev/null || echo 'export LC_ALL=$PROJECT_LOCALE' >> ~/.zshrc
+        "
+        echo "✅ LANG=$PROJECT_LOCALE, LC_ALL=$PROJECT_LOCALE set in agents container shell configs"
+
+        # Clean up temp keypair from host
+        rm -rf "$SSH_TMPDIR"
+
+        # Verify SSH connectivity
+        if docker exec -u vscode "$AGENTS_CONTAINER" ssh -o ConnectTimeout=5 -o BatchMode=yes "$DDEV_USER@web" true 2>/dev/null; then
+            echo "✅ SSH connectivity verified: agents → web"
+        else
+            echo "⚠️  SSH connectivity test failed — sshd may still be starting, try 'ssh $DDEV_USER@web' from agents container"
+        fi
+    fi
+fi
+
+
+# ==============================================================================
+# Pre-populate VS Code User mcp.json for gallery-mode MCP servers
+# ==============================================================================
+# VS Code requires MCP servers to be in User/mcp.json with a "gallery" field
+# for registryOnly access mode. This pre-populates it so the server is
+# auto-enabled without manual @mcp gallery installation.
+WDRMCP_VERSION=$(docker exec "$AGENTS_CONTAINER" npm view @wunderio/wdrmcp version 2>/dev/null || echo "0.1.17")
+SUPERGATEWAY_VERSION=$(docker exec "$AGENTS_CONTAINER" npm view supergateway version 2>/dev/null || echo "3.4.3")
+docker exec -i -u vscode "$AGENTS_CONTAINER" bash -c '
+    mkdir -p ~/.vscode-server/data/User
+    cat > ~/.vscode-server/data/User/mcp.json
+' <<MCPJSON
+{
+  "servers": {
+    "wdrmcp": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@wunderio/wdrmcp@${WDRMCP_VERSION}",
+        "--tools-config",
+        "/workspace/.agents/tools-config"
+      ],
+      "gallery": "https://mcp.wdr.io",
+      "version": "${WDRMCP_VERSION}"
+    },
+    "wunder-quality-system": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "supergateway@${SUPERGATEWAY_VERSION}",
+        "--streamableHttp",
+        "https://quality.wunder.io/mcp",
+        "--oauth2Bearer",
+        "${WQS_MCP_API_KEY}"
+      ],
+      "gallery": "https://mcp.wdr.io",
+      "version": "1.0.0"
+    }
+  },
+  "inputs": []
+}
+MCPJSON
+echo "✅ VS Code MCP gallery config pre-populated (wdrmcp@${WDRMCP_VERSION})"
+
+# ==============================================================================
+# Persist Copilot session data via workspace symlink
+# ==============================================================================
+# /workspace is a bind-mount that survives ddev restarts, so symlinking
+# ~/.copilot → /workspace/.copilot gives free persistence without volume
+# ownership issues. The directory is created here on the host (as the repo
+# owner) so it exists before the symlink is made inside the container.
+mkdir -p "$PROJECT_ROOT/.copilot"
+
+GITIGNORE="$PROJECT_ROOT/.gitignore"
+if [ -f "$GITIGNORE" ] && grep -qx '\.copilot' "$GITIGNORE"; then
+    echo "✅ .copilot already in .gitignore"
+elif [ -f "$GITIGNORE" ]; then
+    echo '.copilot' >> "$GITIGNORE"
+    echo "✅ Added .copilot to .gitignore"
+fi
+
+docker exec -u vscode "$AGENTS_CONTAINER" bash -c '
+    # If ~/.copilot already exists and is not our symlink, migrate its contents
+    if [ -e ~/.copilot ] && [ ! -L ~/.copilot ]; then
+        if cp -rT ~/.copilot /workspace/.copilot 2>/dev/null; then
+            rm -rf ~/.copilot
+        else
+            echo "⚠️  Could not migrate ~/.copilot to /workspace/.copilot — original left in place" >&2
+            exit 1
+        fi
+    fi
+    ln -sfn /workspace/.copilot ~/.copilot
+'
+echo "✅ ~/.copilot symlinked to /workspace/.copilot"
+
+# ==============================================================================
+# Generate Copilot CLI MCP config
+# ==============================================================================
+if [ -d "$PROJECT_ROOT/.agents/tools-config" ]; then
+    # Each server's local config is hashed into a fingerprint and matched
+    # against the registry's fingerprint for that server. The CLI infers the
+    # fingerprint from `command` + `args` (must surface the npm package id) or
+    # from a `type: "http"` URL — anything wrapping the call (e.g. bash -c)
+    # makes the fingerprint uncomputable and the server is blocked under
+    # "Registry only" policy. Each entry below mirrors the shape used in the
+    # registry at https://mcp.wdr.io so fingerprints match.
+    docker exec -i -u vscode "$AGENTS_CONTAINER" bash -c 'cat > ~/.copilot/mcp-config.json' <<MCPCONFIG
+{
+  "mcpServers": {
+    "wdrmcp": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "@wunderio/wdrmcp",
+        "--tools-config",
+        "/workspace/.agents/tools-config"
+      ],
+      "env": {
+        "DDEV_SSH_USER": "${DDEV_USER:-}"
+      },
+      "tools": ["*"]
+    },
+    "wunder-quality-system": {
+      "type": "stdio",
+      "command": "npx",
+      "args": [
+        "-y",
+        "supergateway",
+        "--streamableHttp",
+        "https://quality.wunder.io/mcp",
+        "--oauth2Bearer",
+        "\${WQS_MCP_API_KEY}"
+      ],
+      "tools": ["*"]
+    }
+  }
+}
+MCPCONFIG
+    echo "✅ MCP config generated for Copilot CLI (~/.copilot/mcp-config.json)"
+fi
+
+echo ""
+echo "✅ Setup complete. Open VS Code and select 'Reopen in Container' to attach."

--- a/.ddev/config.agents.yaml
+++ b/.ddev/config.agents.yaml
@@ -1,0 +1,10 @@
+#ddev-generated
+# Hooks configuration for ddev-agents addon
+# This file configures DDEV to build the devcontainer image before starting
+
+hooks:
+  pre-start:
+    - exec-host: .ddev/commands/host/build-devcontainer
+
+  post-start:
+    - exec-host: .ddev/commands/host/set-up

--- a/.ddev/config.wunderio.yaml
+++ b/.ddev/config.wunderio.yaml
@@ -7,13 +7,13 @@ hooks:
     # We check for wdr-core.sh existence (introduced in 0.5.0) to detect if
     # the add-on is missing or a pre-0.5.0 version is installed. Versions 0.5.0
     # and later are checked for updates by host-post-start-update-check.sh.
-    - exec-host: 'if [ ! -f "${DDEV_GLOBAL_DIR}/wunderio/core/wdr-core.sh" ]; then ddev add-on get wunderio/ddev-wunderio-drupal; fi'
+    - exec-host: 'if [ ! -f "${DDEV_GLOBAL_DIR}/homeadditions/wunderio/core/wdr-core.sh" ]; then ddev add-on get wunderio/ddev-wunderio-drupal; fi'
   post-start:
     # Build hook workaround to run composer install on first start.
     # @todo We could potentially make this work from recognizing the command.
     - exec: |
         if ! command -v wdr-core &> /dev/null; then
-          ln -s /mnt/ddev-global-cache/wunderio/core/wdr-core.sh /usr/local/bin/wdr-core
+          ln -s ${HOME}/wunderio/core/wdr-core.sh /usr/local/bin/wdr-core
         fi
         # Run once start hook if needed
         if [ ! -f "/mnt/wdr-hooks/ddev_web_post_start_once" ]; then
@@ -21,11 +21,11 @@ hooks:
           sudo touch /mnt/wdr-hooks/ddev_web_post_start_once
         fi
     # Script to run on every start on the host.
-    - exec-host: '${DDEV_GLOBAL_DIR}/wunderio/core/wdr-core.sh hooks host-post-start.sh'
+    - exec-host: '${DDEV_GLOBAL_DIR}/homeadditions/wunderio/core/wdr-core.sh hooks host-post-start.sh'
     # Script to run on every start.
     - exec: "wdr-core hooks web-post-start.sh"
     # Update check.
-    - exec-host: '${DDEV_GLOBAL_DIR}/wunderio/core/wdr-core.sh hooks host-post-start-update-check.sh'
+    - exec-host: '${DDEV_GLOBAL_DIR}/homeadditions/wunderio/core/wdr-core.sh hooks host-post-start-update-check.sh'
   post-import-db:
     - exec: "wdr-core hooks db-post-import.sh"
   post-restore-snapshot:

--- a/.ddev/config.yaml
+++ b/.ddev/config.yaml
@@ -1,17 +1,17 @@
 name: drupal-project
 type: drupal11
 docroot: web
-php_version: "8.3"
+php_version: "8.4"
 webserver_type: nginx-fpm
 xdebug_enabled: false
 additional_hostnames: []
 additional_fqdns: []
 database:
   type: mariadb
-  version: "10.6"
+  version: "11.4"
 use_dns_when_possible: true
 composer_version: "2"
-nodejs_version: "20"
+nodejs_version: "24"
 # Prevents DDEV from managing settings.php and other Drupal settings files.
 disable_settings_management: true
 web_environment:

--- a/.ddev/copilot-managed-config.json
+++ b/.ddev/copilot-managed-config.json
@@ -1,0 +1,33 @@
+{
+
+  "_comment": "#ddev-generated",
+  "tools": {
+    "deny": [
+      "git push*",
+      "git remote*",
+      "git checkout*",
+      "git reset --hard*",
+      "git clean -f*",
+      "git branch -D*",
+      "npm publish*",
+      "composer publish*",
+      "ssh *",
+      "rm -rf /*",
+      "sudo *"
+    ]
+  },
+  "files": {
+    "deny": [
+      ".env",
+      ".env.*",
+      "*secrets*",
+      "**/credentials*",
+      "**/*.pem",
+      "**/*.key",
+      "**/.npmrc",
+      "**/.htpasswd",
+      "wp-config.php",
+      "**/settings.local.php"
+    ]
+  }
+}

--- a/.ddev/docker-compose.agents.yaml
+++ b/.ddev/docker-compose.agents.yaml
@@ -2,14 +2,32 @@
 services:
   agents:
     container_name: ddev-${DDEV_PROJECT}-agents
-    # Python 3 devcontainer image (supports Apple Silicon)
-    image: mcr.microsoft.com/devcontainers/python:3-bookworm
+    # Using locally built devcontainer image (built via `ddev build-devcontainer`)
+    image: ddev-${DDEV_PROJECT}-devcontainer:latest
     hostname: agents
     user: vscode
     restart: "no"
+    # Security hardening: Drop all Linux capabilities. The container runs as
+    # non-root (vscode), so capabilities are already inert for the running
+    # process. This additionally restricts the bounding set, preventing even
+    # root (via docker exec -u root) from acquiring capabilities.
+    # No cap_add needed — outbound networking, file I/O, and user-level
+    # package installs (pip, npm) all work without any capabilities.
+    cap_drop:
+      - ALL
+    # Security hardening: Prevent privilege escalation via setuid/setgid
+    # binaries. This intentionally disables sudo inside the container,
+    # closing the passwordless-sudo path in the base devcontainer image.
+    # Root access is still available from the host via:
+    #   docker exec -u root -it <container> bash
+    # Devcontainer feature installation is unaffected (runs during image
+    # build, not in the running container).
+    security_opt:
+      - no-new-privileges:true
     volumes:
       - ../:/workspace:cached
       - ddev-global-cache:/mnt/ddev-global-cache
+      - ./copilot-managed-config.json:/home/vscode/.copilot-managed-config.json:ro
     working_dir: /workspace
     environment:
       - DDEV_PROJECT=${DDEV_PROJECT}
@@ -17,3 +35,9 @@ services:
     labels:
       com.ddev.site-name: ${DDEV_PROJECT}
       com.ddev.app-type: agents
+    x-ddev:
+      ssh-shell: zsh
+
+volumes:
+  ddev-global-cache:
+    external: true

--- a/.ddev/docker-compose.wunderio.yaml
+++ b/.ddev/docker-compose.wunderio.yaml
@@ -2,10 +2,7 @@
 services:
   web:
     volumes:
-      # $WUNDERIO_GLOBAL_SCRIPT_ROOT is set in wunderio/core/wdr-core.sh, but
-      # it's not here. So we need to use the full path to the wunderio
-      # directory.
-      - ~/.ddev/wunderio:/mnt/ddev-global-cache/wunderio
+      # Hooks mount to provide some persistent storage.
       - hooks:/mnt/wdr-hooks
 
 # In DDEV all the places which are kept during start and stop are kept in

--- a/.ddev/web-build/Dockerfile.ddev-agents
+++ b/.ddev/web-build/Dockerfile.ddev-agents
@@ -1,0 +1,23 @@
+#ddev-generated
+# Install and configure SSH server for remote command execution from agents container
+
+# Ensure signing key is up to date
+RUN curl -sSL https://packages.sury.org/php/apt.gpg | gpg --dearmor --batch --yes -o /usr/share/keyrings/deb.sury.org-php.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/deb.sury.org-php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list
+
+# Install SSH server
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+        openssh-server \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy custom sshd configuration
+COPY sshd_config /etc/ssh/sshd_config
+
+# Generate host keys and register sshd as a supervised service
+# Note: supervisord runs as the DDEV user, so sudo is needed for sshd (port 22, host key access)
+# /run/sshd is on tmpfs and must be created at runtime
+RUN ssh-keygen -A && \
+    printf '[program:sshd]\ncommand=sudo bash -c "mkdir -p /run/sshd && chown root:root /run/sshd && chmod 755 /run/sshd && exec /usr/sbin/sshd -D"\nautorestart=true\nstartretries=3\n' \
+        > /etc/supervisor/conf.d/sshd.conf

--- a/.ddev/web-build/sshd_config
+++ b/.ddev/web-build/sshd_config
@@ -1,0 +1,41 @@
+#ddev-generated
+# SSHD configuration for DDEV web container
+# Allows SSH access from agents devcontainer for remote command execution
+
+# Basic settings
+Port 22
+Protocol 2
+HostKey /etc/ssh/ssh_host_rsa_key
+HostKey /etc/ssh/ssh_host_ecdsa_key
+HostKey /etc/ssh/ssh_host_ed25519_key
+
+# Authentication
+PubkeyAuthentication yes
+PasswordAuthentication no
+ChallengeResponseAuthentication no
+UsePAM yes
+
+# Don't read user's ~/.rhosts and ~/.shosts files
+IgnoreRhosts yes
+
+# Allow forwarding
+AllowTcpForwarding yes
+X11Forwarding no
+
+# Logging
+SyslogFacility AUTH
+LogLevel INFO
+
+# Security
+PermitRootLogin no
+StrictModes no
+
+# Disable unused authentication methods
+KerberosAuthentication no
+GSSAPIAuthentication no
+
+# Performance
+UseDNS no
+
+# Allow environment variables
+AcceptEnv LANG LC_* DDEV_*

--- a/.devcontainer/devcontainer.build.json
+++ b/.devcontainer/devcontainer.build.json
@@ -1,0 +1,32 @@
+{
+  "containerEnv": {
+    "GH_TOKEN": "${localEnv:DDEV_AGENTS_GH_TOKEN}",
+    "WQS_MCP_API_KEY": "${localEnv:WQS_MCP_API_KEY}"
+  },
+  "remoteEnv": {
+    "GH_TOKEN": "${localEnv:DDEV_AGENTS_GH_TOKEN}",
+    "WQS_MCP_API_KEY": "${localEnv:WQS_MCP_API_KEY}",
+    "SSH_AUTH_SOCK": ""
+  },
+  "name": "Agents: __PROJECT_NAME__ Build",
+  "image": "mcr.microsoft.com/devcontainers/python:3-bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "__NODE_VERSION__"
+    },
+    "ghcr.io/shyim/devcontainers-features/php:latest": {
+      "version": "__PHP_VERSION__",
+      "installComposer": true
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "installDirectlyFromGitHubRelease": true
+    },
+    "ghcr.io/devcontainers/features/copilot-cli:1": {},
+    "ghcr.io/devcontainers/features/git:1": {},
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "installZsh": true,
+      "configureZshAsDefaultShell": true
+    },
+    "ghcr.io/devcontainers-extra/features/ripgrep:1": {}
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,12 +1,14 @@
 {
   "containerEnv": {
-    "GH_TOKEN": "${localEnv:DDEV_AGENTS_GH_TOKEN}"
+    "GH_TOKEN": "${localEnv:DDEV_AGENTS_GH_TOKEN}",
+    "WQS_MCP_API_KEY": "${localEnv:WQS_MCP_API_KEY}"
   },
   "remoteEnv": {
     "GH_TOKEN": "${localEnv:DDEV_AGENTS_GH_TOKEN}",
+    "WQS_MCP_API_KEY": "${localEnv:WQS_MCP_API_KEY}",
     "SSH_AUTH_SOCK": ""
   },
-  "name": "Wunder.io Agents Workspace",
+  "name": "Agents: drupal-project",
   "dockerComposeFile": [
     "../.ddev/.ddev-docker-compose-full.yaml"
   ],
@@ -14,8 +16,10 @@
   "workspaceFolder": "/workspace",
   "shutdownAction": "none",
   "features": {
-    "ghcr.io/devcontainers/features/node:1": {},
-    "ghcr.io/devcontainers/features/php:1": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "24"
+    },
+    "ghcr.io/shyim/devcontainers-features/php:latest": {
       "version": "8.4",
       "installComposer": true
     },
@@ -27,7 +31,8 @@
     "ghcr.io/devcontainers/features/common-utils:2": {
       "installZsh": true,
       "configureZshAsDefaultShell": true
-    }
+    },
+    "ghcr.io/devcontainers-extra/features/ripgrep:1": {}
   },
   "customizations": {
     "vscode": {
@@ -39,13 +44,15 @@
         "redhat.vscode-yaml"
       ],
       "settings": {
-        "git.enabled": false,
+        "git.enabled": true,
         "workbench.activityBar.visible": true,
         "terminal.integrated.defaultProfile.linux": "zsh",
         "github.copilot.enable": {
           "*": true
         },
-        "editor.formatOnSave": true
+        "editor.formatOnSave": true,
+        "chat.mcp.gallery.enabled": true,
+        "chat.mcp.gallery.serviceUrl": "https://mcp.wdr.io"
       }
     },
     "jetbrains": {

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ node_modules
 /blob-report/
 /playwright/.cache/
 /playwright/.auth/
+.copilot

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ For additional instructions, please refer to the [Silta documentation](https://g
 ## Production environment
 
 - **URL**: <https://production.drupal-project.finland.wdr.io>
-- **Drush alias**: `drush @prod st`
+- **Drush alias**: `drush @production st`
 - **SSH**: `ssh www-admin@production-shell.drupal-project -J www-admin@ssh.finland.wdr.io`
 
 ### Environment variables for `silta_finland` context
@@ -88,13 +88,8 @@ This project uses DDEV for local development.
 
   # Synchronize local database with a remote environment
   # Synchronization is provided by [ddev-wunderio-drupal](https://github.com/wunderio/ddev-wunderio-drupal)
+  # drush deploy and drush uli are part of ddev syncdb command.
   ddev syncdb
-
-  # Apply configuration changes
-  ddev drush deploy
-
-  # Get a one-time login link for admin access
-  ddev drush uli
   ```
 
 Note: All commands in the DDEV section should be run within the DDEV environment using `ddev` prefix (e.g., `ddev drush uli`), or by using `ddev ssh` to access the container shell first.
@@ -353,9 +348,9 @@ The project includes ready-to-use Varnish configuration:
 </details>
 
 <details>
-<summary>Running tests</summary>
+<summary>Testing</summary>
 
-### Running tests
+### Testing
 
 #### PHPUnit (unit & integration tests)
 

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ For a complete list of all available services, URLs, and ports, use:
 
 - `ddev` - Display available commands
 - `ddev adminer` - Launch Adminer database management interface
+- `ddev copilot [args]` - Run GitHub Copilot CLI inside the agents container
 - `ddev grumphp <commands>` - Run code quality checks (command provided by [ddev-wunderio-drupal](https://github.com/wunderio/ddev-wunderio-drupal))
 - `ddev mailpit` - Open Mailpit email testing interface
 - `ddev npm <commands>` - Execute npm commands
@@ -224,21 +225,44 @@ ddev npm run lint
 </details>
 
 <details>
-<summary>Cursor AI Code Editor</summary>
+<summary>AI Workflow (ddev-agents + Copilot)</summary>
 
-### Cursor AI Code Editor
+### AI Workflow (ddev-agents + Copilot)
 
-This project uses [Cursor](https://docs.cursor.com/) as the recommended AI-powered IDE. Cursor enhances development productivity through AI-assisted coding features while maintaining compatibility with VSCode extensions and settings.
+This project includes the `ddev-agents` addon for AI-assisted development in the local DDEV environment. It provides MCP tools and a dedicated agents container for running project-aware commands safely.
 
-#### Project-specific AI Rules
+#### Quick start
 
-- Rules are stored in `@.cursor/rules/` directory
-- Main configuration file: `@.cursor/rules/common.mdc`
-- Rules provide AI with project-specific context about:
-  - File organization and key project files
-  - Development environment setup
-  - Code standards and technology stack
-  - Git workflow and commit message formatting
+1. Start the project:
+
+   ```bash
+   ddev start
+   ```
+
+2. Open the project in the devcontainer.
+
+3. Open VS Code Copilot chat and start the local MCP server (`wdrmcp`) from MCP server controls.
+
+4. Use project tools through Copilot chat, or run Copilot CLI directly:
+
+   ```bash
+   ddev copilot
+   ```
+
+#### Project AI configuration
+
+- Tool definitions: `.agents/tools-config/`
+- Addon metadata: `.ddev/addon-metadata/ddev-agents/manifest.yaml`
+- Agents runtime config: `.ddev/config.agents.yaml`
+- Copilot managed restrictions: `.ddev/copilot-managed-config.json`
+
+#### Security model
+
+- Commands run via SSH with ephemeral keys generated at each `ddev start`.
+- No Docker socket access is required in the agents workflow.
+- Keys are distributed into containers during startup and are not persisted on host by default.
+
+For deeper usage, custom tools, and environment variables, see `.agents/README.md`.
 
 </details>
 
@@ -436,7 +460,7 @@ feat(GH-57): Add release automation command
 Rules:
 
 - Ticket format: `PROJECTKEY-123` (for example `WNDR-446`, `GH-57`).
-- Subject must start with a capital letter after `: `.
+- Subject must start with a capital letter after `:`.
 - Allowed types in `type(...)`: `feat`, `fix`, `chore`, `docs`, `style`, `refactor`, `perf`, `test`, `ci`, `build`, `revert`.
 - Merge commits are excluded from this validation.
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "wunderio/drupal-project",
-    "description": "Wunder's template for Drupal projects.",
+    "description": "Mearra's template for Drupal projects.",
     "type": "project",
     "license": "GPL-2.0-or-later",
     "homepage": "https://www.drupal.org/project/drupal",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": ">=8.3",
+        "php": ">=8.4",
         "composer/installers": "^2.3",
         "cweagans/composer-patches": "^2.0",
         "drupal/admin_toolbar": "^3.6",

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         "cweagans/composer-patches": "^2.0",
         "drupal/admin_toolbar": "^3.6",
         "drupal/config_split": "^2.0",
-        "drupal/core-composer-scaffold": "^11.3",
-        "drupal/core-recommended": "^11.3",
+        "drupal/core-composer-scaffold": "^11.4",
+        "drupal/core-recommended": "^11.4",
         "drupal/monolog": "^3.0",
         "drupal/purge": "^3.6",
         "drupal/simplei": "^3.0",
@@ -33,7 +33,7 @@
         "wunderio/updates_log": "^2.5"
     },
     "require-dev": {
-        "drupal/core-dev": "^11.3",
+        "drupal/core-dev": "^11.4",
         "wunderio/code-quality": "^3.0"
     },
     "conflict": {
@@ -51,6 +51,7 @@
             "php-http/discovery": true,
             "phpro/grumphp": true,
             "phpstan/extension-installer": true,
+            "symfony/runtime": true,
             "tbachert/spi": true
         },
         "discard-changes": true,

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "drupal/monolog": "^3.0",
         "drupal/purge": "^3.6",
         "drupal/simplei": "^3.0",
-        "drupal/stage_file_proxy": "^3.1",
+        "drupal/stage_file_proxy": "^4.0",
         "drupal/varnish_purge": "^2.3",
         "drush/drush": "^13.7",
         "vlucas/phpdotenv": "^5.6",

--- a/config/local/stage_file_proxy.settings.yml
+++ b/config/local/stage_file_proxy.settings.yml
@@ -3,7 +3,7 @@ _core:
 hotlink: false
 origin: ''
 origin_dir: ''
-use_imagecache_root: true
 proxy_headers: ''
+use_imagecache_root: true
 verify: true
 excluded_extensions: ''

--- a/config/sync/system.date.yml
+++ b/config/sync/system.date.yml
@@ -1,6 +1,6 @@
 _core:
   default_config_hash: IVsFTD1mvR2NGBP_1myt9kFIFmGepH4PyaN5aQBYpno
-first_day: 0
+first_day: 1
 country:
   default: null
 timezone:

--- a/drush/Commands/PolicyCommands.php
+++ b/drush/Commands/PolicyCommands.php
@@ -18,7 +18,8 @@ class PolicyCommands extends DrushCommands {
    * @throws \Exception
    */
   public function sqlSyncValidate(CommandData $commandData) {
-    if ($commandData->input()->getArgument('target') == '@prod') {
+    $target = (string) $commandData->input()->getArgument('target');
+    if ($target === '@prod' || $target === '@production') {
       throw new \Exception(dt('Per !file, you may never overwrite the production database.', ['!file' => __FILE__]));
     }
   }
@@ -31,7 +32,8 @@ class PolicyCommands extends DrushCommands {
    * @throws \Exception
    */
   public function rsyncValidate(CommandData $commandData) {
-    if (preg_match("/^@prod/", $commandData->input()->getArgument('target'))) {
+    $target = (string) $commandData->input()->getArgument('target');
+    if (preg_match('/^@(prod|production)/', $target)) {
       throw new \Exception(dt('Per !file, you may never rsync to the production site.', ['!file' => __FILE__]));
     }
   }

--- a/drush/Commands/SiltaAliasAlterCommands.php
+++ b/drush/Commands/SiltaAliasAlterCommands.php
@@ -60,7 +60,7 @@ class SiltaAliasAlterCommands extends DrushCommands {
         ]);
 
         // Preflight may have cached @self before reference data was set; remote
-        // commands (e.g. drush @prod uli) use getSelf() for SSH, so reload it.
+        // commands (e.g. drush @production uli) use getSelf() for SSH, so reload it.
         $self = $this->siteAliasManager->getSelf();
         $host = $self->get('host');
         if (is_string($host) && str_contains($host, '${')) {

--- a/drush/sites/self.site.yml
+++ b/drush/sites/self.site.yml
@@ -1,8 +1,5 @@
 # Edit or remove this file as needed.
 # Docs at https://github.com/drush-ops/drush/blob/master/examples/example.site.yml
-local:
-  root: ${env.DDEV_APPROOT}/${env.DDEV_DOCROOT}
-  uri: https://${env.DDEV_HOSTNAME}
 
 current:
   host: ${ENVIRONMENT}-shell.${REPOSITORY}
@@ -20,7 +17,7 @@ main:
   root: /app/web
   uri: https://main.${PROJECT}.dev.wdr.io
 
-prod:
+production:
   host: production-shell.${REPOSITORY}
   ssh:
     options: -J www-admin@ssh.finland.wdr.io

--- a/grumphp.yml
+++ b/grumphp.yml
@@ -20,7 +20,7 @@ grumphp:
         'The commit must start with the JIRA or GitHub issue number': '/^((feat|fix|chore|docs|style|refactor|perf|test|ci|build|revert)\([A-Z][A-Z0-9_]+-[1-9][0-9]*\)|[A-Z][A-Z0-9_]+-[1-9][0-9]*): [A-Z]/'
     php_compatibility:
       run_on: '%grumphp.run_on_paths%'
-      testVersion: '8.3'
+      testVersion: '8.4'
     check_file_permissions: ~
     php_check_syntax:
       run_on: '%grumphp.run_on_paths%'

--- a/patches.lock.json
+++ b/patches.lock.json
@@ -1,0 +1,4 @@
+{
+    "_hash": "6142bfcb78f54dfbf5247ae5e463f25bdb8fff1890806e2e45aa81a59c211653",
+    "patches": []
+}

--- a/silta/php.Dockerfile
+++ b/silta/php.Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for the PHP container.
-FROM wunderio/silta-php-fpm:8.3-fpm-v1
+FROM wunderio/silta-php-fpm:8.4-fpm-v1
 
 COPY --chown=www-data:www-data . /app
 

--- a/silta/shell.Dockerfile
+++ b/silta/shell.Dockerfile
@@ -1,4 +1,4 @@
 # Dockerfile for the Shell container.
-FROM wunderio/silta-php-shell:php8.3-v1
+FROM wunderio/silta-php-shell:php8.4-v1
 
 COPY --chown=www-data:www-data . /app

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -38,6 +38,10 @@ $settings['file_scan_ignore_directories'] = [
   'bower_components',
 ];
 
+// Disable HTML5 validation.
+// See: https://www.drupal.org/node/3537128.
+$settings['enable_html5_validation'] = FALSE;
+
 // Varnish Purge configuration.
 if (getenv('VARNISH_ADMIN_HOST')) {
   $config['varnish_purger.settings.c6013ef2d0']['hostname'] = trim(getenv('VARNISH_ADMIN_HOST'));


### PR DESCRIPTION
## Ticket WNDR-481

## Changes
- Upgrade runtime baselines to PHP 8.4, Node 24, and MariaDB 11.4 across CI, DDEV, and Silta images
- Update `wunderio/ddev-wunderio-drupal` to the latest version
- Disable HTML5 form validation explicitly in site settings for forward-compatible behavior
- Update Drush production alias handling to support @production while preserving @prod safety checks

## Testing
- GrumPHP hooks passed on commits (phpcs, phpstan, phpunit, yaml/json lint, commit message checks)
- Verified targeted PHP unit test execution previously in DDEV

Note that failing Playwright tests are resolved in https://github.com/wunderio/drupal-project/pull/469.
